### PR TITLE
Fix CLI release tarball path

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -48,7 +48,7 @@ jobs:
           mkdir -p dist
           npm pack ./packages/cli --json --pack-destination dist > cli-pack.json
           node scripts/audit-cli-pack.mjs cli-pack.json
-          TARBALL="$(node -p "'dist/' + require('./cli-pack.json')[0].filename")"
+          TARBALL="$(node -p "'./dist/' + require('./cli-pack.json')[0].filename")"
           VERSION="$(node -p "require('./cli-pack.json')[0].version")"
           echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/docs/CLI_RELEASE.md
+++ b/docs/CLI_RELEASE.md
@@ -16,7 +16,7 @@ npm login
 npm version 0.1.0-beta.0 --prefix packages/cli --no-git-tag-version
 npm pack ./packages/cli --json --pack-destination dist > cli-pack.json
 node scripts/audit-cli-pack.mjs cli-pack.json
-tarball="$(node -p "'dist/' + require('./cli-pack.json')[0].filename")"
+tarball="$(node -p "'./dist/' + require('./cli-pack.json')[0].filename")"
 npm publish "$tarball" --access public --tag bootstrap --provenance=false
 ```
 

--- a/tests/cli_package_test.mjs
+++ b/tests/cli_package_test.mjs
@@ -8,6 +8,7 @@ import { auditPackReport } from '../scripts/audit-cli-pack.mjs';
 const rootPackage = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const cliPackage = JSON.parse(fs.readFileSync('packages/cli/package.json', 'utf8'));
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const publishWorkflow = fs.readFileSync('.github/workflows/publish-cli.yml', 'utf8');
 
 assert.equal(rootPackage.private, true);
 assert.equal(rootPackage.bin, undefined);
@@ -18,6 +19,11 @@ assert.deepEqual(cliPackage.bin, { lamina: './bin/lamina.mjs' });
 assert.equal(cliPackage.engines.node, '>=20');
 assert.equal(cliPackage.license, 'Apache-2.0');
 assert.equal(cliPackage.dependencies['@ladybugdb/core'], '0.18.3');
+assert.match(
+  publishWorkflow,
+  /TARBALL=.*'\.\/dist\/'/,
+  'release tarball must use an explicit local path so npm does not parse it as a registry spec',
+);
 
 for (const runtimePath of [
   'skills/lamina-orchestrator/bin',


### PR DESCRIPTION
## What

- prefixes packed CLI tarball paths with `./` in the bootstrap runbook and stable release workflow
- adds a regression assertion to the CLI package test

## Why

npm interprets a bare `dist/package.tgz` argument as a package or hosted-git spec in this release environment. The explicit `./dist/package.tgz` form unambiguously selects the locally audited tarball.

## Impact

The beta bootstrap and stable OIDC workflow publish the exact tarball produced and audited in the preceding step.

## Checks

- `node tests/cli_package_test.mjs`
- `git diff --check`
- reproduced the failure with `dist/laminadev-cli-0.1.0-beta.0.tgz` and confirmed npm reaches the registry with `./dist/laminadev-cli-0.1.0-beta.0.tgz`