### PR TITLE
Fix CLI skill installation instructions

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,14 +19,14 @@ its pinned CocoIndex Python project.
 Install the skills independently from GitHub:
 
 ```bash
-npx skills install aryaniyaps/lamina
+npx skills add aryaniyaps/lamina --all -y
 ```
 
 For the complete setup:
 
 ```bash
 npm install -g @laminadev/cli
-npx skills install aryaniyaps/lamina
+npx skills add aryaniyaps/lamina --all -y
 ```
 
 ## Observation
@@ -55,7 +55,7 @@ package, and reinstall the skills:
 ```bash
 npm unlink -g lamina
 npm install -g @laminadev/cli
-npx skills install aryaniyaps/lamina
+npx skills add aryaniyaps/lamina --all -y
 ```
 
 The graph remains in the Git common directory at `.git/lamina`; the migration


### PR DESCRIPTION
## What changed

- replaced the removed `npx skills install` form in the packaged CLI README
- standardized standalone, combined, and migration setup on `npx skills add aryaniyaps/lamina --all -y`

## Why

`@laminadev/cli` is about to be published, so the README embedded in the npm tarball must contain an executable installation path before the package becomes public.

## Validation

- `git diff --check`
- `node scripts/audit-cli-pack.mjs <pack.json>`
- `node tests/cli_tarball_smoke_test.mjs --tarball <tarball>`
