### PR TITLE
Fix standalone compatibility matrix

### DIFF
--- a/evals/hooks/skills-sandbox.sh
+++ b/evals/hooks/skills-sandbox.sh
@@ -7,8 +7,6 @@ SANDBOX="$LAMINA_ROOT/evals/harness-sandbox"
 
 mkdir -p "$SANDBOX"
 
-EXTERNAL_SKILLS_ROOT="$(cd "$LAMINA_ROOT/../skills" && pwd)"
-
 skills_add() {
   local args=("$@")
   local has_skill=false
@@ -25,7 +23,9 @@ skills_add() {
 }
 
 skills_add_external() {
-  (cd "$SANDBOX" && npx --yes skills add "$EXTERNAL_SKILLS_ROOT" --skill '*' -a cursor -y --copy "$@")
+  local external_skills_root
+  external_skills_root="$(cd "$LAMINA_ROOT/../skills" && pwd)"
+  (cd "$SANDBOX" && npx --yes skills add "$external_skills_root" --skill '*' -a cursor -y --copy "$@")
 }
 
 skills_dry_run() {


### PR DESCRIPTION
## What changed

Resolve the optional sibling skills repository only when external skills are explicitly installed.

## Why

The CLI release workflow runs the in-repository compatibility matrix in a clean GitHub checkout. Eagerly resolving ../skills caused that matrix to fail after all repository tests passed, even though the matrix never uses the external repository.

## Validation

- corepack pnpm test:eval:compat (13/13 agents)
- bash -n evals/hooks/skills-sandbox.sh evals/hooks/compatibility-matrix.sh
- git diff --check