### PR TITLE
perf: capture real-repository runtime baseline

### DIFF
--- a/.github/workflows/runtime-baseline.yml
+++ b/.github/workflows/runtime-baseline.yml
@@ -40,7 +40,8 @@ jobs:
 
   baseline:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-22.04
+    # cli-v0.3.5's published Linux worker requires glibc 2.38 or newer.
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     env:
       LAMINA_SAFE_RUNNER_STATE_DIR: /tmp/lamina-runtime-baseline-safe-state

--- a/.github/workflows/runtime-baseline.yml
+++ b/.github/workflows/runtime-baseline.yml
@@ -40,8 +40,7 @@ jobs:
 
   baseline:
     if: github.event_name == 'workflow_dispatch'
-    # cli-v0.3.5's published Linux worker requires glibc 2.38 or newer.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 360
     env:
       LAMINA_SAFE_RUNNER_STATE_DIR: /tmp/lamina-runtime-baseline-safe-state
@@ -73,15 +72,23 @@ jobs:
             "$(sha256sum "$node_dir/node" | cut -d' ' -f1)"
           printf '%s\n' "$node_dir" >> "$GITHUB_PATH"
 
-      - name: Verify system bubblewrap authority
+      - name: Provision pinned rootless bubblewrap
         shell: bash
         run: |
-          test "$(realpath /usr/bin/bwrap)" = /usr/bin/bwrap
-          test "$(stat -c '%u' /usr/bin/bwrap)" = 0
-          mode="$(stat -c '%a' /usr/bin/bwrap)"
-          test $((8#$mode & 022)) -eq 0
-          /usr/bin/bwrap --version
-          sha256sum /usr/bin/bwrap
+          package_dir="$RUNNER_TEMP/bubblewrap-package"
+          extract_dir="$RUNNER_TEMP/bubblewrap-root"
+          bin_dir="$RUNNER_TEMP/bubblewrap-bin"
+          mkdir -p "$package_dir" "$extract_dir" "$bin_dir"
+          package="$package_dir/bubblewrap_0.8.0-2+deb12u1_amd64.deb"
+          package_url="https://deb.debian.org/debian/pool/main/b/bubblewrap/bubblewrap_0.8.0-2+deb12u1_amd64.deb"
+          package_sha256="3cc9134a3286ad01a323dcd924ba123eb634cefaeec82d774257e06308aeaadb"
+          curl --proto '=https' --tlsv1.2 -fsSL "$package_url" -o "$package"
+          printf '%s  %s\n' "$package_sha256" "$package" | sha256sum --check
+          dpkg-deb --extract "$package" "$extract_dir"
+          cp "$extract_dir/usr/bin/bwrap" "$bin_dir/bwrap"
+          chmod 0755 "$bin_dir/bwrap"
+          printf 'LAMINA_SAFE_BWRAP_PATH=%s\nLAMINA_SAFE_BWRAP_SHA256=%s\n' \
+            "$bin_dir/bwrap" "$(sha256sum "$bin_dir/bwrap" | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Download checksum-pinned runtime inputs
         shell: bash

--- a/.github/workflows/runtime-baseline.yml
+++ b/.github/workflows/runtime-baseline.yml
@@ -1,0 +1,140 @@
+name: Real repository runtime baseline
+
+on:
+  pull_request:
+    paths:
+      - 'benchmarks/runtime-baseline-v1/**'
+      - 'tests/runtime_baseline_test.mjs'
+      - 'scripts/safe-runner/**'
+      - 'package.json'
+      - '.github/workflows/runtime-baseline.yml'
+  workflow_dispatch:
+    inputs:
+      fixture:
+        description: Exact pinned fixture tier to measure
+        required: true
+        type: choice
+        options: [small, medium, large]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-baseline-v1
+  cancel-in-progress: false
+
+jobs:
+  contracts:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          package-manager-cache: false
+      - run: corepack pnpm install --frozen-lockfile
+      - run: npm run test:runtime-baseline
+
+  baseline:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    env:
+      LAMINA_SAFE_RUNNER_STATE_DIR: /tmp/lamina-runtime-baseline-safe-state
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          package-manager-cache: false
+
+      - run: corepack pnpm install --frozen-lockfile
+
+      - name: Stage trusted private Node runtime
+        shell: bash
+        run: |
+          source_node="$(realpath "$(command -v node)")"
+          source_bin="$(dirname "$source_node")"
+          source_root="$(dirname "$source_bin")"
+          trust_root="$RUNNER_TEMP/lamina-safe-node"
+          node_dir="$trust_root/bin"
+          install -d -m 0700 "$trust_root"
+          cp -a --no-preserve=ownership "$source_root/." "$trust_root/"
+          chmod -R go-w "$trust_root"
+          chmod 0700 "$trust_root"
+          test "$(sha256sum "$source_node" | cut -d' ' -f1)" = \
+            "$(sha256sum "$node_dir/node" | cut -d' ' -f1)"
+          printf '%s\n' "$node_dir" >> "$GITHUB_PATH"
+
+      - name: Provision pinned rootless bubblewrap
+        shell: bash
+        run: |
+          package_dir="$RUNNER_TEMP/bubblewrap-package"
+          extract_dir="$RUNNER_TEMP/bubblewrap-root"
+          bin_dir="$RUNNER_TEMP/bubblewrap-bin"
+          mkdir -p "$package_dir" "$extract_dir" "$bin_dir"
+          package="$package_dir/bubblewrap_0.8.0-2+deb12u1_amd64.deb"
+          package_url="https://deb.debian.org/debian/pool/main/b/bubblewrap/bubblewrap_0.8.0-2+deb12u1_amd64.deb"
+          package_sha256="3cc9134a3286ad01a323dcd924ba123eb634cefaeec82d774257e06308aeaadb"
+          curl --proto '=https' --tlsv1.2 -fsSL "$package_url" -o "$package"
+          printf '%s  %s\n' "$package_sha256" "$package" | sha256sum --check
+          dpkg-deb --extract "$package" "$extract_dir"
+          cp "$extract_dir/usr/bin/bwrap" "$bin_dir/bwrap"
+          chmod 0755 "$bin_dir/bwrap"
+          printf 'LAMINA_SAFE_BWRAP_PATH=%s\nLAMINA_SAFE_BWRAP_SHA256=%s\n' \
+            "$bin_dir/bwrap" "$(sha256sum "$bin_dir/bwrap" | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Download checksum-pinned runtime inputs
+        shell: bash
+        run: |
+          input_dir="$GITHUB_WORKSPACE/dist/runtime-baseline-inputs"
+          mkdir -p "$input_dir"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            https://github.com/aryaniyaps/lamina/releases/download/cli-v0.3.5/lamina-retrieval-model-int8-v1.onnx \
+            -o "$input_dir/model.onnx"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            https://github.com/aryaniyaps/lamina/releases/download/cli-v0.3.5/lamina-cocoindex-worker-linux-x64 \
+            -o "$input_dir/cocoindex-worker"
+          printf '%s  %s\n' \
+            ed45870251c9f0cf656e78aab0d37a23489066df8a222bb1c8caf8a45f2cb16d "$input_dir/model.onnx" \
+            119247359266f2a5b922b03c76d052bc76d757ec634593fbf52473bfc8ee79cc "$input_dir/cocoindex-worker" | sha256sum --check
+          chmod 0700 "$input_dir/cocoindex-worker"
+          printf 'LAMINA_BASELINE_MODEL=%s\nLAMINA_BASELINE_WORKER=%s\n' \
+            "$input_dir/model.onnx" "$input_dir/cocoindex-worker" >> "$GITHUB_ENV"
+
+      - name: Qualify aggregate enforcement
+        run: npm run safe:self-test -- --require-production
+
+      - name: Run one fixture sequentially
+        run: |
+          node benchmarks/runtime-baseline-v1/run.mjs run \
+            --fixture '${{ inputs.fixture }}' \
+            --output "$RUNNER_TEMP/runtime-baseline-${{ inputs.fixture }}" \
+            --model "$LAMINA_BASELINE_MODEL" \
+            --worker "$LAMINA_BASELINE_WORKER"
+
+      - name: Refuse leaked runtime processes
+        if: always()
+        shell: bash
+        run: |
+          if pgrep -af '[r]untime-baseline-v1|[c]ocoindex-worker|[g]raph-runtime/server.mjs' > "$RUNNER_TEMP/runtime-baseline-leftovers.txt"; then
+            cat "$RUNNER_TEMP/runtime-baseline-leftovers.txt"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: runtime-baseline-${{ inputs.fixture }}
+          include-hidden-files: true
+          if-no-files-found: error
+          path: |
+            ${{ runner.temp }}/runtime-baseline-${{ inputs.fixture }}
+            /tmp/lamina-runtime-baseline-safe-state
+            ${{ runner.temp }}/runtime-baseline-leftovers.txt

--- a/.github/workflows/runtime-baseline.yml
+++ b/.github/workflows/runtime-baseline.yml
@@ -73,23 +73,15 @@ jobs:
             "$(sha256sum "$node_dir/node" | cut -d' ' -f1)"
           printf '%s\n' "$node_dir" >> "$GITHUB_PATH"
 
-      - name: Provision pinned rootless bubblewrap
+      - name: Verify system bubblewrap authority
         shell: bash
         run: |
-          package_dir="$RUNNER_TEMP/bubblewrap-package"
-          extract_dir="$RUNNER_TEMP/bubblewrap-root"
-          bin_dir="$RUNNER_TEMP/bubblewrap-bin"
-          mkdir -p "$package_dir" "$extract_dir" "$bin_dir"
-          package="$package_dir/bubblewrap_0.8.0-2+deb12u1_amd64.deb"
-          package_url="https://deb.debian.org/debian/pool/main/b/bubblewrap/bubblewrap_0.8.0-2+deb12u1_amd64.deb"
-          package_sha256="3cc9134a3286ad01a323dcd924ba123eb634cefaeec82d774257e06308aeaadb"
-          curl --proto '=https' --tlsv1.2 -fsSL "$package_url" -o "$package"
-          printf '%s  %s\n' "$package_sha256" "$package" | sha256sum --check
-          dpkg-deb --extract "$package" "$extract_dir"
-          cp "$extract_dir/usr/bin/bwrap" "$bin_dir/bwrap"
-          chmod 0755 "$bin_dir/bwrap"
-          printf 'LAMINA_SAFE_BWRAP_PATH=%s\nLAMINA_SAFE_BWRAP_SHA256=%s\n' \
-            "$bin_dir/bwrap" "$(sha256sum "$bin_dir/bwrap" | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          test "$(realpath /usr/bin/bwrap)" = /usr/bin/bwrap
+          test "$(stat -c '%u' /usr/bin/bwrap)" = 0
+          mode="$(stat -c '%a' /usr/bin/bwrap)"
+          test $((8#$mode & 022)) -eq 0
+          /usr/bin/bwrap --version
+          sha256sum /usr/bin/bwrap
 
       - name: Download checksum-pinned runtime inputs
         shell: bash

--- a/.github/workflows/safe-runner.yml
+++ b/.github/workflows/safe-runner.yml
@@ -65,7 +65,10 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # Node 24 exercises the execve sandbox-launch path. The unchanged
+          # Node 20 spawn fallback remains covered by CLI compatibility and the
+          # pre-change full #59 qualification history.
+          node-version: '24'
           package-manager-cache: false
 
       - name: Stage trusted private Node runtime

--- a/benchmarks/runtime-baseline-v1/BASELINE.md
+++ b/benchmarks/runtime-baseline-v1/BASELINE.md
@@ -1,0 +1,74 @@
+# Real-repository runtime baseline v1
+
+## Status
+
+Blocked on 2026-08-02. No latency, memory, footprint, or cardinality value from
+the attempted runs is an accepted baseline measurement.
+
+The harness and its safety boundary are implemented, but the published
+`cli-v0.3.5` Linux x64 worker and the available safely enforceable hosts have no
+compatible intersection:
+
+- Ubuntu 22.04 passes the complete adversarial safe-runner qualification, but
+  the worker requires `GLIBC_2.38`; Ubuntu 22.04 provides an older glibc.
+- Ubuntu 24.04 provides a compatible glibc, but a downloaded rootless
+  bubblewrap executable is denied by the host's user-namespace policy. The
+  hosted image does not provide `/usr/bin/bwrap` for the distribution policy to
+  authorize.
+- The local Linux host provides production cgroup-v2 enforcement, but its
+  kernel also refuses unprivileged user namespace creation.
+
+Medium and large were not dispatched. That is intentional: #59 requires a
+successful small run and verified descendant cleanup before promotion.
+
+## Pinned inputs
+
+| Tier | Repository | Commit | Declared source class | Languages | Measured inventory |
+| --- | --- | --- | --- | --- | --- |
+| Small | `alan2207/bulletproof-react` | `9506629ed003a561c6627735480cce4994244bb4` | 10k-50k nonblank tracked source LOC | TypeScript, React | Blocked before fixture preparation |
+| Medium | `outline/outline` | `30730179b852d42da5078a9294f7d05a44f516b7` | 100k-300k nonblank tracked source LOC | TypeScript, React | Not run |
+| Large | `makeplane/plane` | `dc9d80b2d2a499b967f0b541e083b283f463719f` | Realistic polyglot monorepo | TypeScript, React, Python | Not run |
+
+The runtime inputs are the published `cli-v0.3.5` assets:
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `lamina-cocoindex-worker-linux-x64` | 88,690,440 | `119247359266f2a5b922b03c76d052bc76d757ec634593fbf52473bfc8ee79cc` |
+| `lamina-retrieval-model-int8-v1.onnx` | 161,895,621 | `ed45870251c9f0cf656e78aab0d37a23489066df8a222bb1c8caf8a45f2cb16d` |
+
+The manifest is authoritative for repository URLs, exclusion rules, file
+allowlists, LOC ranges, file-size ceiling, and asset URLs.
+
+## Execution evidence
+
+| Environment | Safe-runner result | Workload result | Cleanup | Evidence |
+| --- | --- | --- | --- | --- |
+| GitHub Ubuntu 22.04, 16 GiB, head `541d1726` | Full production qualification passed | Small `footprint` failed while extracting the pinned worker: its bundled Python required `GLIBC_2.38` from `libm.so.6` | Zero remaining descendants and managed paths; scope and temporary directory removed; orphan scan empty | [Actions run 30725039365](https://github.com/aryaniyaps/lamina/actions/runs/30725039365) |
+| GitHub Ubuntu 24.04, 16 GiB, head `2d39cc1b` | Refused before qualification: downloaded bubblewrap could not create its UID map | Not released | Cleanup verification passed; orphan scan empty | [Actions run 30725180790](https://github.com/aryaniyaps/lamina/actions/runs/30725180790) |
+| GitHub Ubuntu 24.04, head `0a56cc94` | System bubblewrap authority was unavailable because `/usr/bin/bwrap` is absent | Not released | Orphan scan empty | [Actions run 30725277619](https://github.com/aryaniyaps/lamina/actions/runs/30725277619) |
+
+The Ubuntu 22.04 artifact contains a schema-valid invalid result for small
+`footprint`, its raw safe-runner report, the passing self-test reports, and an
+empty orphan file. The other eleven small scenarios are explicitly recorded as
+blocked after the first failure. Failure-scope peaks are diagnostics only and
+must not be used as baseline measurements.
+
+## Rejected bypasses
+
+- Running outside #59 or without aggregate process-tree enforcement.
+- Retrying after removing or increasing safety limits.
+- Adding swap or changing host/kernel memory or namespace behavior.
+- Patching the worker's ELF interpreter, adding a loader wrapper, or substituting
+  an unpinned worker; each would measure a different runtime.
+- Promoting medium or large after the failed small scenario.
+
+## Safest unblock
+
+Publish a checksum-pinned Linux x64 worker built from the same runtime sources
+against the oldest supported glibc (at most glibc 2.35), then update only the
+manifest's published asset identity and repeat the full small run. The alternative
+is a trusted host that simultaneously provides glibc 2.38 or newer, user-systemd
+cgroup-v2 aggregate enforcement, quota-backed private temporary storage, and a
+policy-authorized rootless bubblewrap. In either case, rerun the complete #59
+self-test before releasing the fixture and preserve small-to-medium-to-large
+promotion order.

--- a/benchmarks/runtime-baseline-v1/BASELINE.md
+++ b/benchmarks/runtime-baseline-v1/BASELINE.md
@@ -2,35 +2,25 @@
 
 ## Status
 
-Blocked on 2026-08-02. No latency, memory, footprint, or cardinality value from
-the attempted runs is an accepted baseline measurement.
+Recorded through the first enforced safety refusal on 2026-08-02. The small
+fixture produced valid footprint and cold doctor/status/startup results. Its
+initial observation then reached the unchanged aggregate `pids.max=64` ceiling,
+so that scenario is invalid and every later scenario and tier is explicitly
+blocked. The PID-limit peaks are safety diagnostics, not performance samples.
 
-The harness and its safety boundary are implemented, but the published
-`cli-v0.3.5` Linux x64 worker and the available safely enforceable hosts have no
-compatible intersection:
-
-- Ubuntu 22.04 passes the complete adversarial safe-runner qualification, but
-  the worker requires `GLIBC_2.38`; Ubuntu 22.04 provides an older glibc.
-- Ubuntu 24.04 provides a compatible glibc, but a downloaded rootless
-  bubblewrap executable is denied by the host's user-namespace policy. The
-  hosted image does not provide `/usr/bin/bwrap` for the distribution policy to
-  authorize.
-- The local Linux host now provides glibc 2.43, production cgroup-v2
-  enforcement, and working rootless user/private-tmp namespaces. Full #59
-  qualification still refuses before payload release because its isolated
-  network namespace cannot configure loopback (`RTM_NEWADDR` is denied by the
-  host policy).
-
-Medium and large were not dispatched. That is intentional: #59 requires a
-successful small run and verified descendant cleanup before promotion.
+This is the truthful unoptimized baseline. The harness measures the public CLI
+commands and does not alter Lamina's stores, model, worker topology, batching,
+chunking, exclusions, or quality thresholds. Raising the PID limit or bypassing
+the safe runner would answer a different and unsafe question. Issue #51 owns the
+measured task-concurrency bottleneck.
 
 ## Pinned inputs
 
-| Tier | Repository | Commit | Declared source class | Languages | Measured inventory |
+| Tier | Repository | Commit | Declared source class | Languages | Result |
 | --- | --- | --- | --- | --- | --- |
-| Small | `alan2207/bulletproof-react` | `9506629ed003a561c6627735480cce4994244bb4` | 10k-50k nonblank tracked source LOC | TypeScript, React | Blocked before fixture preparation |
-| Medium | `outline/outline` | `30730179b852d42da5078a9294f7d05a44f516b7` | 100k-300k nonblank tracked source LOC | TypeScript, React | Not run |
-| Large | `makeplane/plane` | `dc9d80b2d2a499b967f0b541e083b283f463719f` | Realistic polyglot monorepo | TypeScript, React, Python | Not run |
+| Small | `alan2207/bulletproof-react` | `9506629ed003a561c6627735480cce4994244bb4` | 10k-50k nonblank tracked source LOC | TypeScript, React | Promoted; stopped at initial observation |
+| Medium | `outline/outline` | `30730179b852d42da5078a9294f7d05a44f516b7` | 100k-300k nonblank tracked source LOC | TypeScript, React | Not dispatched: small did not complete |
+| Large | `makeplane/plane` | `dc9d80b2d2a499b967f0b541e083b283f463719f` | Realistic polyglot monorepo | TypeScript, React, Python | Not dispatched: small did not complete |
 
 The runtime inputs are the published `cli-v0.3.5` assets:
 
@@ -39,41 +29,141 @@ The runtime inputs are the published `cli-v0.3.5` assets:
 | `lamina-cocoindex-worker-linux-x64` | 88,690,440 | `119247359266f2a5b922b03c76d052bc76d757ec634593fbf52473bfc8ee79cc` |
 | `lamina-retrieval-model-int8-v1.onnx` | 161,895,621 | `ed45870251c9f0cf656e78aab0d37a23489066df8a222bb1c8caf8a45f2cb16d` |
 
-The manifest is authoritative for repository URLs, exclusion rules, file
-allowlists, LOC ranges, file-size ceiling, and asset URLs.
+The versioned manifest remains authoritative for repository URLs, exclusion
+rules, file allowlists, LOC ranges, file-size ceiling, and asset URLs.
 
-## Execution evidence
+## Qualified execution environment
 
-| Environment | Safe-runner result | Workload result | Cleanup | Evidence |
-| --- | --- | --- | --- | --- |
-| GitHub Ubuntu 22.04, 16 GiB, head `541d1726` | Full production qualification passed | Small `footprint` failed while extracting the pinned worker: its bundled Python required `GLIBC_2.38` from `libm.so.6` | Zero remaining descendants and managed paths; scope and temporary directory removed; orphan scan empty | [Actions run 30725039365](https://github.com/aryaniyaps/lamina/actions/runs/30725039365) |
-| GitHub Ubuntu 24.04, 16 GiB, head `2d39cc1b` | Refused before qualification: downloaded bubblewrap could not create its UID map | Not released | Cleanup verification passed; orphan scan empty | [Actions run 30725180790](https://github.com/aryaniyaps/lamina/actions/runs/30725180790) |
-| GitHub Ubuntu 24.04, head `0a56cc94` | System bubblewrap authority was unavailable because `/usr/bin/bwrap` is absent | Not released | Orphan scan empty | [Actions run 30725277619](https://github.com/aryaniyaps/lamina/actions/runs/30725277619) |
-| Local Linux x64, glibc 2.43, head `01db8b18` | Production adapter detected; user namespace and quota probe passed; full #59 qualification refused because bubblewrap could not configure loopback in the isolated network namespace: `Failed RTM_NEWADDR: Operation not permitted` | Not released | All ten bounded qualification reports recorded sandbox-launch failure; zero descendants and managed paths remained; temporary directory, watchdog directory, lock, and systemd scope were absent | `LAMINA_SAFE_RUNNER_STATE_DIR=/tmp/lamina-issue60-recheck-safe-state npm run safe:self-test -- --require-production` |
+| Field | Value |
+| --- | --- |
+| Lamina commit | `c087420266f7d6231c37fa9afc6c445b51bff48e` |
+| Host | Linux x64, kernel `7.0.0-28-generic`, Intel Core Ultra 9 185H |
+| Memory | 65,562,333,184 bytes |
+| Runtime | Node `v24.18.0`; glibc `2.43` |
+| Sandbox | `/usr/bin/bwrap`, 80,424 bytes, SHA-256 `0abea81db798ebf6b4742ac0664802d97521547a353c2a0dbdc21d76cbbfd2c0`, root-owned, one link, no file capabilities |
+| Enforcement | user-systemd cgroup v2, aggregate memory/PID ownership, private quota-backed tmpfs, isolated network/PID/user namespaces |
+| Hard limits | memory 3 GiB, high 2.4 GiB, 64 tasks, 30 minutes, 1 MiB output, 2 GiB temporary data, 8,192 temporary inodes |
 
-The Ubuntu 22.04 artifact contains a schema-valid invalid result for small
-`footprint`, its raw safe-runner report, the passing self-test reports, and an
-empty orphan file. The other eleven small scenarios are explicitly recorded as
-blocked after the first failure. Failure-scope peaks are diagnostics only and
-must not be used as baseline measurements.
+Immediately before measurement, the complete production adversarial command
 
-## Rejected bypasses
+```sh
+LAMINA_SAFE_RUNNER_STATE_DIR=/tmp/lamina-issue60-final-safe-state \
+  npm run safe:self-test -- --require-production
+```
 
-- Running outside #59 or without aggregate process-tree enforcement.
-- Retrying after removing or increasing safety limits.
-- Adding swap or changing host/kernel memory or namespace behavior.
-- Patching the worker's ELF interpreter, adding a loader wrapper, or substituting
-  an unpinned worker; each would measure a different runtime.
-- Promoting medium or large after the failed small scenario.
+passed all cases. It proved direct and aggregate memory enforcement, PID,
+timeout, output, temporary-disk, controller-signal, supervisor-SIGKILL,
+detached-descendant, and exact cleanup behavior. Every case reported
+`cleanup_verified: true`; the attestation time was `2026-08-02T05:39:04.219Z`.
 
-## Safest unblock
+The host path for the root-owned distribution bwrap is intentional. Ubuntu's
+path-based AppArmor policy recognizes the distribution executable but not a
+byte-identical temporary copy. ADR-014 records the root-ownership, ancestry,
+mode, inode, digest, link-count, and empty-file-capability requirements. Pinned
+or user-owned bwrap inputs still execute from sealed copies.
 
-Publish a checksum-pinned Linux x64 worker built from the same runtime sources
-against the oldest supported glibc (at most glibc 2.35), then update only the
-manifest's published asset identity and repeat the full small run. The alternative
-is a trusted host that simultaneously provides glibc 2.38 or newer, user-systemd
-cgroup-v2 aggregate enforcement, quota-backed private temporary storage, and a
-policy-authorized rootless bubblewrap whose isolated network namespace passes the
-full #59 adversarial qualification. In either case, rerun the complete #59
-self-test before releasing the fixture and preserve small-to-medium-to-large
-promotion order.
+## Small fixture inventory
+
+| Measure | Value |
+| --- | ---: |
+| Tracked files | 535 |
+| Tracked bytes | 2,640,087 |
+| Tracked source files | 438 |
+| Tracked source bytes | 628,504 |
+| Tracked nonblank source LOC | 20,450 |
+| Observation candidate files / bytes | 535 / 2,640,087 |
+| Retrieval candidate files / bytes | 467 / 693,785 |
+| Source CLI files / bytes | 34 / 89,144,519 |
+| Prepared runtime files / bytes | 4 / 5,950,249 |
+| Sealed model bytes | 161,895,621 |
+| Sealed worker bytes | 88,690,440 |
+
+Excluded roots are `.git`, public agent-skill mirrors, Lamina runs/runtime state,
+`node_modules`, Python caches and virtual environments, `.next`, `dist`,
+`build`, `coverage`, benchmark results, and vendored eval temporary trees. The
+observation path-set digest is
+`a751c5ae498aad42ec231daf714f8bede3e76f1d6f083ccbe3b6097f666b07cc`;
+the retrieval path-set digest is
+`8915cb111c9232dd2645d5b470e95fcfddc8a2293f4cc6881a9727c52864d52b`.
+
+## Valid measurements
+
+All three cold samples include public CLI startup, argument parsing, dispatch,
+and graphd startup. Nanosecond values are reported as milliseconds below for
+readability; the JSON retains exact integer nanoseconds.
+
+| Scenario | Samples | Median | Maximum | Aggregate run envelope |
+| --- | --- | ---: | ---: | --- |
+| Installation/extracted footprint | static | n/a | n/a | 6,069 ms; 404,770,816-byte cgroup peak; 33-task peak; cleanup zero |
+| Doctor/status and graph startup | 459.175, 462.817, 430.490 ms | 459.175 ms | 462.817 ms | 6,403-6,800 ms; 403,865,600-405,061,632-byte cgroup peaks; 46-56-task peaks; cleanup zero |
+
+Doctor itself took 56.699-71.994 ms. Status plus cold graphd startup took
+373.732-397.216 ms. These are three cold samples, so no p90 or p95 is claimed.
+
+## Enforced refusal and promotion fence
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| Initial observation | Invalid: aggregate PID safety limit | 9,817 ms to stop; 64-task sampled peak; `pids.events.max=5`; 696,369,152-byte cgroup diagnostic peak; SIGTERM requested; zero descendants and managed paths; scope and temporary directory removed |
+| Initial retrieval readiness | Blocked after previous failure | Not released |
+| First useful preparation | Blocked after previous failure | Not released |
+| Warm preparation | Blocked after previous failure | Not released |
+| No-op synchronization | Blocked after previous failure | Not released |
+| One-file / multi-file change | Blocked after previous failure | Not released |
+| Full derived-state rebuild | Blocked after previous failure | Not released |
+| Post-command idle RSS | Blocked after previous failure | Not released |
+| Cancellation/shutdown/orphans | Blocked after previous failure | Covered only by the preceding production qualification, not claimed as a product-baseline result |
+| Medium / large | Blocked by small-tier promotion fence | Never dispatched |
+
+The bounded descendant diagnostics identify overlapping native/runtime demand:
+the asset-extraction worker reached 45 threads, graphd 29, the public CLI 7, and
+the observation worker 17 before the controller stopped the scope. These maxima
+are sampled per-process diagnostics and are not assumed to be simultaneous.
+They nominate concurrency control as a bottleneck without selecting an
+architecture.
+
+## Result identity and reproduction
+
+The schema-valid local result set is preserved at
+`/tmp/lamina-runtime-baseline-small-20260802-r29` on the qualifying host. Its
+index SHA-256 is
+`658420c27ff3d6c85af7c439173cb6bdbf0756afc894b99bb6344360abe24801`.
+Raw safe-runner report digests are:
+
+- footprint: `580d25c35f51738808d77d052225dda9a65eb55a1777f5ae53833ff7617743a3`;
+- doctor/status samples: `1b736ca81ee88894036a2fd75faaaa58b68596e514c4eecb46d068988e4a78c5`, `0bd786210e01cbf8c4e86140efe6cefa1cc651f5f8a9e2e0af929fccc8d1c366`, and `70f77302b830b7fc45e05bd2520699a65108ddec9779be8dec9e001b5d889fff`;
+- initial-observation refusal: `e4d72608b688c0981013676e450c9764c0718689e311b03121562c4df8e4da4f`.
+
+After downloading the two checksum-pinned assets to the paths shown below, a
+compatible Linux host can reproduce the run without source edits:
+
+```sh
+LAMINA_SAFE_RUNNER_STATE_DIR=/tmp/lamina-runtime-baseline-safe-state \
+  npm run safe:self-test -- --require-production
+
+LAMINA_SAFE_RUNNER_STATE_DIR=/tmp/lamina-runtime-baseline-safe-state \
+  node benchmarks/runtime-baseline-v1/run.mjs run \
+    --fixture small \
+    --output /tmp/lamina-runtime-baseline-small \
+    --model dist/runtime-baseline-inputs/model.onnx \
+    --worker dist/runtime-baseline-inputs/cocoindex-worker
+```
+
+The second command exits 2 because the index truthfully contains an invalid
+safety-limited scenario. Repeating it requires a fresh output directory; it
+must not be retried with raised limits. A compatible host must provide cgroup-v2
+aggregate enforcement, a quota-backed private temporary filesystem, and a
+policy-authorized unprivileged bwrap. Medium and large remain forbidden until a
+small run completes after a reviewed runtime improvement.
+
+## Historical host refusals
+
+- [Ubuntu 22.04 run 30725039365](https://github.com/aryaniyaps/lamina/actions/runs/30725039365)
+  passed production qualification but could not load the pinned worker because
+  it requires `GLIBC_2.38`.
+- [Ubuntu 24.04 run 30725180790](https://github.com/aryaniyaps/lamina/actions/runs/30725180790)
+  had a compatible glibc but its downloaded bwrap was denied a UID map.
+- [Ubuntu 24.04 run 30725277619](https://github.com/aryaniyaps/lamina/actions/runs/30725277619)
+  had no policy-authorized `/usr/bin/bwrap`.
+
+These failures remain useful portability evidence but are not measurements.

--- a/benchmarks/runtime-baseline-v1/BASELINE.md
+++ b/benchmarks/runtime-baseline-v1/BASELINE.md
@@ -15,8 +15,11 @@ compatible intersection:
   bubblewrap executable is denied by the host's user-namespace policy. The
   hosted image does not provide `/usr/bin/bwrap` for the distribution policy to
   authorize.
-- The local Linux host provides production cgroup-v2 enforcement, but its
-  kernel also refuses unprivileged user namespace creation.
+- The local Linux host now provides glibc 2.43, production cgroup-v2
+  enforcement, and working rootless user/private-tmp namespaces. Full #59
+  qualification still refuses before payload release because its isolated
+  network namespace cannot configure loopback (`RTM_NEWADDR` is denied by the
+  host policy).
 
 Medium and large were not dispatched. That is intentional: #59 requires a
 successful small run and verified descendant cleanup before promotion.
@@ -46,6 +49,7 @@ allowlists, LOC ranges, file-size ceiling, and asset URLs.
 | GitHub Ubuntu 22.04, 16 GiB, head `541d1726` | Full production qualification passed | Small `footprint` failed while extracting the pinned worker: its bundled Python required `GLIBC_2.38` from `libm.so.6` | Zero remaining descendants and managed paths; scope and temporary directory removed; orphan scan empty | [Actions run 30725039365](https://github.com/aryaniyaps/lamina/actions/runs/30725039365) |
 | GitHub Ubuntu 24.04, 16 GiB, head `2d39cc1b` | Refused before qualification: downloaded bubblewrap could not create its UID map | Not released | Cleanup verification passed; orphan scan empty | [Actions run 30725180790](https://github.com/aryaniyaps/lamina/actions/runs/30725180790) |
 | GitHub Ubuntu 24.04, head `0a56cc94` | System bubblewrap authority was unavailable because `/usr/bin/bwrap` is absent | Not released | Orphan scan empty | [Actions run 30725277619](https://github.com/aryaniyaps/lamina/actions/runs/30725277619) |
+| Local Linux x64, glibc 2.43, head `01db8b18` | Production adapter detected; user namespace and quota probe passed; full #59 qualification refused because bubblewrap could not configure loopback in the isolated network namespace: `Failed RTM_NEWADDR: Operation not permitted` | Not released | All ten bounded qualification reports recorded sandbox-launch failure; zero descendants and managed paths remained; temporary directory, watchdog directory, lock, and systemd scope were absent | `LAMINA_SAFE_RUNNER_STATE_DIR=/tmp/lamina-issue60-recheck-safe-state npm run safe:self-test -- --require-production` |
 
 The Ubuntu 22.04 artifact contains a schema-valid invalid result for small
 `footprint`, its raw safe-runner report, the passing self-test reports, and an
@@ -69,6 +73,7 @@ against the oldest supported glibc (at most glibc 2.35), then update only the
 manifest's published asset identity and repeat the full small run. The alternative
 is a trusted host that simultaneously provides glibc 2.38 or newer, user-systemd
 cgroup-v2 aggregate enforcement, quota-backed private temporary storage, and a
-policy-authorized rootless bubblewrap. In either case, rerun the complete #59
+policy-authorized rootless bubblewrap whose isolated network namespace passes the
+full #59 adversarial qualification. In either case, rerun the complete #59
 self-test before releasing the fixture and preserve small-to-medium-to-large
 promotion order.

--- a/benchmarks/runtime-baseline-v1/contract.mjs
+++ b/benchmarks/runtime-baseline-v1/contract.mjs
@@ -1,0 +1,72 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const BASELINE_SCHEMA = 'lamina.runtime-baseline-result/v1';
+export const WORKLOAD_SCHEMA = 'lamina.runtime-baseline-workload/v1';
+export const MANIFEST_SCHEMA = 'lamina.runtime-baseline-manifest/v1';
+export const SCENARIOS = Object.freeze([
+  'footprint',
+  'doctor-status-startup',
+  'initial-observation',
+  'initial-retrieval-readiness',
+  'first-useful-preparation',
+  'warm-preparation',
+  'noop-synchronization',
+  'one-file-change',
+  'multi-file-change',
+  'full-derived-state-rebuild',
+  'post-command-idle-rss',
+  'cancellation-shutdown-cleanup',
+]);
+export const COLD_RUNS = 3;
+export const WARM_SAMPLES = 30;
+export const WARMUP_SAMPLES = 1;
+export const MAX_WORKLOAD_OUTPUT_BYTES = 7 * 1024;
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MANIFEST_FILE = path.join(HERE, 'manifest.json');
+
+export const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+
+export function loadManifest() {
+  const bytes = fs.readFileSync(MANIFEST_FILE);
+  const manifest = JSON.parse(bytes);
+  if (manifest.schema !== MANIFEST_SCHEMA || manifest.version !== 1
+    || !Array.isArray(manifest.fixtures) || manifest.fixtures.length !== 3) {
+    throw new Error('runtime baseline manifest is invalid');
+  }
+  return { manifest, digest: sha256(bytes), file: MANIFEST_FILE };
+}
+
+export function fixtureById(id) {
+  const { manifest } = loadManifest();
+  const fixture = manifest.fixtures.find((item) => item.id === id);
+  if (!fixture) throw new Error(`unknown runtime baseline fixture: ${id}`);
+  return fixture;
+}
+
+export function assertScenario(scenario) {
+  if (!SCENARIOS.includes(scenario)) throw new Error(`unknown runtime baseline scenario: ${scenario}`);
+  return scenario;
+}
+
+export function summarizeNanoseconds(samples, warm) {
+  if (!Array.isArray(samples) || samples.length === 0
+    || samples.some((value) => !Number.isSafeInteger(value) || value < 0)) {
+    throw new Error('latency samples must be non-empty non-negative safe integers');
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  const percentile = (fraction) => sorted[Math.ceil(sorted.length * fraction) - 1];
+  const middle = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 ? sorted[middle]
+    : Math.round((sorted[middle - 1] + sorted[middle]) / 2);
+  return {
+    count: samples.length,
+    median,
+    maximum: sorted.at(-1),
+    p90: warm && samples.length >= WARM_SAMPLES ? percentile(0.90) : null,
+    p95: warm && samples.length >= WARM_SAMPLES ? percentile(0.95) : null,
+  };
+}

--- a/benchmarks/runtime-baseline-v1/manifest.json
+++ b/benchmarks/runtime-baseline-v1/manifest.json
@@ -1,0 +1,58 @@
+{
+  "schema": "lamina.runtime-baseline-manifest/v1",
+  "version": 1,
+  "fixtures": [
+    {
+      "id": "small",
+      "name": "Bulletproof React",
+      "url": "https://github.com/alan2207/bulletproof-react.git",
+      "commit": "9506629ed003a561c6627735480cce4994244bb4",
+      "class": "small",
+      "source_loc": { "minimum": 10000, "maximum": 50000 },
+      "languages": ["TypeScript", "React"]
+    },
+    {
+      "id": "medium",
+      "name": "Outline",
+      "url": "https://github.com/outline/outline.git",
+      "commit": "30730179b852d42da5078a9294f7d05a44f516b7",
+      "class": "medium",
+      "source_loc": { "minimum": 100000, "maximum": 300000 },
+      "languages": ["TypeScript", "React"]
+    },
+    {
+      "id": "large",
+      "name": "Plane",
+      "url": "https://github.com/makeplane/plane.git",
+      "commit": "dc9d80b2d2a499b967f0b541e083b283f463719f",
+      "class": "large",
+      "source_loc": { "minimum": 300000, "maximum": 1500000 },
+      "languages": ["TypeScript", "React", "Python"],
+      "polyglot": true
+    }
+  ],
+  "source_extensions": [
+    ".c", ".cc", ".cpp", ".cs", ".css", ".go", ".h", ".hpp", ".html",
+    ".java", ".js", ".jsx", ".kt", ".kts", ".mjs", ".php", ".py", ".rb",
+    ".rs", ".scss", ".swift", ".ts", ".tsx", ".vue"
+  ],
+  "exclusions": [
+    ".git", ".agents/skills", ".claude/skills", ".codex/skills", ".opencode/skills",
+    ".lamina/runs", ".lamina/runtime", ".lamina/runtime-cli", "node_modules",
+    "__pycache__", ".venv*", ".next", "dist", "build", "coverage",
+    "benchmarks/results", "evals/fixtures/.vendor-tmp*"
+  ],
+  "runtime_assets": {
+    "release": "cli-v0.3.5",
+    "worker_linux_x64": {
+      "url": "https://github.com/aryaniyaps/lamina/releases/download/cli-v0.3.5/lamina-cocoindex-worker-linux-x64",
+      "sha256": "119247359266f2a5b922b03c76d052bc76d757ec634593fbf52473bfc8ee79cc",
+      "bytes": 88690440
+    },
+    "model": {
+      "url": "https://github.com/aryaniyaps/lamina/releases/download/cli-v0.3.5/lamina-retrieval-model-int8-v1.onnx",
+      "sha256": "ed45870251c9f0cf656e78aab0d37a23489066df8a222bb1c8caf8a45f2cb16d",
+      "bytes": 161895621
+    }
+  }
+}

--- a/benchmarks/runtime-baseline-v1/manifest.json
+++ b/benchmarks/runtime-baseline-v1/manifest.json
@@ -36,6 +36,12 @@
     ".java", ".js", ".jsx", ".kt", ".kts", ".mjs", ".php", ".py", ".rb",
     ".rs", ".scss", ".swift", ".ts", ".tsx", ".vue"
   ],
+  "retrieval_extensions": [
+    ".c", ".cc", ".cpp", ".css", ".go", ".h", ".hpp", ".html", ".java",
+    ".js", ".jsx", ".json", ".kt", ".md", ".mdx", ".mjs", ".php", ".py",
+    ".rb", ".rs", ".scss", ".sql", ".swift", ".ts", ".tsx", ".vue", ".yaml", ".yml"
+  ],
+  "retrieval_max_file_bytes": 2097152,
   "exclusions": [
     ".git", ".agents/skills", ".claude/skills", ".codex/skills", ".opencode/skills",
     ".lamina/runs", ".lamina/runtime", ".lamina/runtime-cli", "node_modules",

--- a/benchmarks/runtime-baseline-v1/run.mjs
+++ b/benchmarks/runtime-baseline-v1/run.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runSafely } from '../../scripts/safe-runner/runner.mjs';
+import { validateReport as validateSafeRunnerReport } from '../../scripts/safe-runner/report.mjs';
+import { fixtureById, loadManifest, SCENARIOS } from './contract.mjs';
+import {
+  validateScenarioResult, validateWorkloadRecord, workloadRecordFromReport,
+} from './validate.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY = path.resolve(HERE, '../..');
+const WORKLOAD = path.join(HERE, 'workload.mjs');
+const LIMITS = Object.freeze({
+  memoryMaxBytes: 3 * 1024 ** 3,
+  memoryHighBytes: Math.floor(2.75 * 1024 ** 3),
+  pidsMax: 64,
+  timeoutMs: 30 * 60_000,
+  outputMaxBytes: 1024 * 1024,
+  tempMaxBytes: 2 * 1024 ** 3,
+  sampleIntervalMs: 250,
+  sustainedHighSamples: 4,
+  gracefulStopMs: 2_000,
+});
+
+const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+const stableJson = (value) => `${JSON.stringify(value, null, 2)}\n`;
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  if (!args[index + 1] || args[index + 1].startsWith('--')) throw new Error(`${name} requires a value`);
+  return args[index + 1];
+}
+
+function initializeOutput(requested) {
+  const root = path.resolve(requested);
+  if (root === REPOSITORY || root.startsWith(`${REPOSITORY}${path.sep}`)) {
+    throw new Error('baseline output must be outside the source repository');
+  }
+  if (fs.existsSync(root)) throw new Error('baseline output must not already exist');
+  fs.mkdirSync(path.join(root, 'raw'), { recursive: true, mode: 0o700 });
+  return root;
+}
+
+function tierChain(fixture) {
+  return fixture.id === 'large' ? ['small', 'medium', 'large']
+    : fixture.id === 'medium' ? ['small', 'medium'] : ['small'];
+}
+
+async function runScenario({ root, fixture, scenario, model, worker }) {
+  const command = [process.execPath, WORKLOAD, 'run', fixture.id, scenario, model, worker];
+  const runs = [];
+  let workload = null;
+  let status = 'valid';
+  for (const tier of tierChain(fixture)) {
+    const relative = `raw/${fixture.id}-${scenario}-${tier}.json`;
+    const reportFile = path.join(root, relative);
+    const report = await runSafely({
+      command, tier, cwd: REPOSITORY, reportFile, overrides: LIMITS,
+      workloadId: `runtime-baseline-v1:${fixture.id}:${scenario}`, promote: true,
+    });
+    const safeValidation = validateSafeRunnerReport(report);
+    if (!safeValidation.valid) throw new Error(`${relative}: ${safeValidation.errors.join('; ')}`);
+    const bytes = fs.readFileSync(reportFile);
+    runs.push({
+      tier: report.tier,
+      outcome: report.outcome,
+      limit: report.termination.limit,
+      duration_ms: report.duration_ms,
+      peak_memory_bytes: report.peaks.cgroup_memory_bytes,
+      peak_pids: report.peaks.pids,
+      peak_temporary_bytes: report.peaks.temporary_bytes,
+      remaining_descendants: report.cleanup.descendants_remaining.length,
+      remaining_managed_paths: report.cleanup.managed_paths_remaining.length,
+      raw_report: relative,
+      raw_report_sha256: sha256(bytes),
+    });
+    if (report.outcome !== 'success') {
+      status = report.outcome === 'preflight_refused' ? 'refused' : 'invalid';
+      break;
+    }
+    workload = workloadRecordFromReport(report);
+    const workloadValidation = validateWorkloadRecord(workload, { fixtureId: fixture.id, scenario });
+    if (!workloadValidation.valid) throw new Error(`${relative}: ${workloadValidation.errors.join('; ')}`);
+  }
+  const result = {
+    schema: 'lamina.runtime-baseline-result/v1',
+    generated_at: new Date().toISOString(),
+    status,
+    fixture: { id: fixture.id, commit: fixture.commit, url: fixture.url },
+    scenario,
+    measured_tier: tierChain(fixture).at(-1),
+    workload,
+    runs,
+    limitations: [
+      'Linux x64 baseline; other platforms are not represented.',
+      'CocoIndex worker and production retrieval model are checksum-pinned release assets; current JavaScript CLI and graphd come from the measured Lamina commit.',
+    ],
+  };
+  const file = path.join(root, `${fixture.id}-${scenario}.json`);
+  fs.writeFileSync(file, stableJson(result), { flag: 'wx', mode: 0o600 });
+  const validation = validateScenarioResult(result, root);
+  if (!validation.valid) throw new Error(`${path.basename(file)}: ${validation.errors.join('; ')}`);
+  return { file, result };
+}
+
+async function main(args) {
+  const command = args[0];
+  if (command === 'validate') {
+    const file = option(args, '--file');
+    if (!file) throw new Error('validate requires --file');
+    const result = JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
+    const validation = validateScenarioResult(result, path.dirname(path.resolve(file)));
+    process.stdout.write(stableJson(validation));
+    return validation.valid ? 0 : 1;
+  }
+  if (command !== 'run') throw new Error('usage: run.mjs run --fixture ID --output DIR --model FILE --worker FILE');
+  const fixture = fixtureById(option(args, '--fixture'));
+  const output = initializeOutput(option(args, '--output'));
+  const model = path.resolve(option(args, '--model'));
+  const worker = path.resolve(option(args, '--worker'));
+  const { digest: manifestDigest } = loadManifest();
+  const completed = [];
+  for (const scenario of SCENARIOS) {
+    const run = await runScenario({ root: output, fixture, scenario, model, worker });
+    completed.push(path.basename(run.file));
+    if (run.result.status !== 'valid') break;
+  }
+  const index = {
+    schema: 'lamina.runtime-baseline-index/v1',
+    generated_at: new Date().toISOString(),
+    manifest_digest: manifestDigest,
+    host: { platform: process.platform, release: os.release(), architecture: process.arch, cpu: os.cpus()[0]?.model || 'unknown', memory_bytes: os.totalmem() },
+    fixture: fixture.id,
+    completed,
+    expected: SCENARIOS.length,
+    complete: completed.length === SCENARIOS.length,
+  };
+  fs.writeFileSync(path.join(output, 'index.json'), stableJson(index), { flag: 'wx', mode: 0o600 });
+  process.stdout.write(stableJson({ output, ...index }));
+  return index.complete ? 0 : 2;
+}
+
+try {
+  process.exitCode = await main(process.argv.slice(2));
+} catch (error) {
+  process.stderr.write(stableJson({ schema: 'lamina.runtime-baseline-cli-error/v1', error: { message: error.message } }));
+  process.exitCode = 2;
+}

--- a/benchmarks/runtime-baseline-v1/run.mjs
+++ b/benchmarks/runtime-baseline-v1/run.mjs
@@ -6,7 +6,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runSafely } from '../../scripts/safe-runner/runner.mjs';
 import { validateReport as validateSafeRunnerReport } from '../../scripts/safe-runner/report.mjs';
-import { fixtureById, loadManifest, SCENARIOS } from './contract.mjs';
+import {
+  COLD_RUNS, fixtureById, loadManifest, SCENARIOS, summarizeNanoseconds,
+} from './contract.mjs';
 import {
   validateScenarioResult, validateWorkloadRecord, workloadRecordFromReport,
 } from './validate.mjs';
@@ -36,6 +38,16 @@ function option(args, name) {
   return args[index + 1];
 }
 
+function assertExactOptions(args, names) {
+  if (args.length !== 1 + names.length * 2) throw new Error('baseline command has unexpected arguments');
+  const supplied = args.slice(1).filter((_value, index) => index % 2 === 0);
+  if (supplied.length !== new Set(supplied).size
+    || supplied.some((name) => !names.includes(name))
+    || names.some((name) => !supplied.includes(name))) {
+    throw new Error('baseline command requires each documented option exactly once');
+  }
+}
+
 function initializeOutput(requested) {
   const root = path.resolve(requested);
   if (root === REPOSITORY || root.startsWith(`${REPOSITORY}${path.sep}`)) {
@@ -54,20 +66,22 @@ function tierChain(fixture) {
 async function runScenario({ root, fixture, scenario, model, worker }) {
   const command = [process.execPath, WORKLOAD, 'run', fixture.id, scenario, model, worker];
   const runs = [];
-  let workload = null;
+  const workloadRecords = [];
   let status = 'valid';
-  for (const tier of tierChain(fixture)) {
-    const relative = `raw/${fixture.id}-${scenario}-${tier}.json`;
+  const execute = async (tier, { label, promote, sampleIndex }) => {
+    const relative = `raw/${fixture.id}-${scenario}-${label}.json`;
     const reportFile = path.join(root, relative);
     const report = await runSafely({
       command, tier, cwd: REPOSITORY, reportFile, overrides: LIMITS,
-      workloadId: `runtime-baseline-v1:${fixture.id}:${scenario}`, promote: true,
+      workloadId: `runtime-baseline-v1:${fixture.id}:${scenario}`, promote,
     });
     const safeValidation = validateSafeRunnerReport(report);
     if (!safeValidation.valid) throw new Error(`${relative}: ${safeValidation.errors.join('; ')}`);
     const bytes = fs.readFileSync(reportFile);
     runs.push({
       tier: report.tier,
+      purpose: label.startsWith('promotion-') ? 'promotion-and-measurement' : 'measurement',
+      sample_index: sampleIndex,
       outcome: report.outcome,
       limit: report.termination.limit,
       duration_ms: report.duration_ms,
@@ -81,11 +95,46 @@ async function runScenario({ root, fixture, scenario, model, worker }) {
     });
     if (report.outcome !== 'success') {
       status = report.outcome === 'preflight_refused' ? 'refused' : 'invalid';
-      break;
+      return false;
     }
-    workload = workloadRecordFromReport(report);
+    const workload = workloadRecordFromReport(report);
     const workloadValidation = validateWorkloadRecord(workload, { fixtureId: fixture.id, scenario });
     if (!workloadValidation.valid) throw new Error(`${relative}: ${workloadValidation.errors.join('; ')}`);
+    workloadRecords.push(workload);
+    return true;
+  };
+  const tiers = tierChain(fixture);
+  for (let index = 0; index < tiers.length; index += 1) {
+    const ok = await execute(tiers[index], {
+      label: `promotion-${tiers[index]}`, promote: true,
+      sampleIndex: index === tiers.length - 1 ? 0 : null,
+    });
+    if (!ok) break;
+  }
+  if (status === 'valid' && workloadRecords.at(-1)?.classification === 'cold-sample') {
+    for (let index = 1; index < COLD_RUNS; index += 1) {
+      const ok = await execute(tiers.at(-1), {
+        label: `measurement-${index}`, promote: false, sampleIndex: index,
+      });
+      if (!ok) break;
+    }
+  }
+  let workload = workloadRecords.at(-1) || null;
+  if (status === 'valid' && workload?.classification === 'cold-sample') {
+    const measured = workloadRecords.slice(-COLD_RUNS);
+    const samples = measured.map((record, index) => ({ ...record.samples[0], index }));
+    workload = {
+      ...workload,
+      classification: 'cold',
+      samples,
+      statistics: summarizeNanoseconds(samples.map((sample) => sample.wall_time_ns), false),
+      diagnostics: measured.flatMap((record) => record.diagnostics || []),
+      cleanup: {
+        repository_removed: measured.every((record) => record.cleanup.repository_removed),
+        socket_removed: measured.every((record) => record.cleanup.socket_removed),
+        lock_removed: measured.every((record) => record.cleanup.lock_removed),
+      },
+    };
   }
   const result = {
     schema: 'lamina.runtime-baseline-result/v1',
@@ -111,6 +160,7 @@ async function runScenario({ root, fixture, scenario, model, worker }) {
 async function main(args) {
   const command = args[0];
   if (command === 'validate') {
+    assertExactOptions(args, ['--file']);
     const file = option(args, '--file');
     if (!file) throw new Error('validate requires --file');
     const result = JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
@@ -119,17 +169,25 @@ async function main(args) {
     return validation.valid ? 0 : 1;
   }
   if (command !== 'run') throw new Error('usage: run.mjs run --fixture ID --output DIR --model FILE --worker FILE');
+  assertExactOptions(args, ['--fixture', '--output', '--model', '--worker']);
   const fixture = fixtureById(option(args, '--fixture'));
   const output = initializeOutput(option(args, '--output'));
   const model = path.resolve(option(args, '--model'));
   const worker = path.resolve(option(args, '--worker'));
   const { digest: manifestDigest } = loadManifest();
   const completed = [];
+  const outcomes = new Map();
   for (const scenario of SCENARIOS) {
     const run = await runScenario({ root: output, fixture, scenario, model, worker });
     completed.push(path.basename(run.file));
+    outcomes.set(scenario, run.result.status);
     if (run.result.status !== 'valid') break;
   }
+  const scenarioOutcomes = SCENARIOS.map((scenario) => ({
+    scenario,
+    status: outcomes.get(scenario) || 'blocked_after_previous_failure',
+  }));
+  const complete = scenarioOutcomes.every((item) => item.status === 'valid');
   const index = {
     schema: 'lamina.runtime-baseline-index/v1',
     generated_at: new Date().toISOString(),
@@ -137,8 +195,9 @@ async function main(args) {
     host: { platform: process.platform, release: os.release(), architecture: process.arch, cpu: os.cpus()[0]?.model || 'unknown', memory_bytes: os.totalmem() },
     fixture: fixture.id,
     completed,
+    scenarios: scenarioOutcomes,
     expected: SCENARIOS.length,
-    complete: completed.length === SCENARIOS.length,
+    complete,
   };
   fs.writeFileSync(path.join(output, 'index.json'), stableJson(index), { flag: 'wx', mode: 0o600 });
   process.stdout.write(stableJson({ output, ...index }));

--- a/benchmarks/runtime-baseline-v1/schema/result.schema.json
+++ b/benchmarks/runtime-baseline-v1/schema/result.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lamina.dev/schemas/runtime-baseline-result-v1.json",
+  "title": "Lamina real-repository runtime baseline scenario result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "generated_at", "status", "fixture", "scenario", "measured_tier",
+    "workload", "runs", "limitations"
+  ],
+  "properties": {
+    "schema": { "const": "lamina.runtime-baseline-result/v1" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["valid", "refused", "invalid"] },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "commit", "url"],
+      "properties": {
+        "id": { "enum": ["small", "medium", "large"] },
+        "commit": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "url": { "type": "string", "pattern": "^https://github\\.com/" }
+      }
+    },
+    "scenario": { "type": "string" },
+    "measured_tier": { "enum": ["small", "medium", "large"] },
+    "workload": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "object", "required": ["schema", "fixture", "scenario", "repository", "classification", "cleanup"] }
+      ]
+    },
+    "runs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "tier", "purpose", "sample_index", "outcome", "limit", "duration_ms", "peak_memory_bytes", "peak_pids",
+          "peak_temporary_bytes", "remaining_descendants", "remaining_managed_paths",
+          "raw_report", "raw_report_sha256"
+        ],
+        "properties": {
+          "tier": { "enum": ["small", "medium", "large"] },
+          "purpose": { "enum": ["promotion-and-measurement", "measurement"] },
+          "sample_index": { "type": ["integer", "null"], "minimum": 0 },
+          "outcome": { "type": "string" },
+          "limit": { "type": ["string", "null"] },
+          "duration_ms": { "type": "integer", "minimum": 0 },
+          "peak_memory_bytes": { "type": "integer", "minimum": 0 },
+          "peak_pids": { "type": "integer", "minimum": 0 },
+          "peak_temporary_bytes": { "type": "integer", "minimum": 0 },
+          "remaining_descendants": { "type": "integer", "minimum": 0 },
+          "remaining_managed_paths": { "type": "integer", "minimum": 0 },
+          "raw_report": { "type": "string" },
+          "raw_report_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+        }
+      }
+    },
+    "limitations": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+  }
+}

--- a/benchmarks/runtime-baseline-v1/validate.mjs
+++ b/benchmarks/runtime-baseline-v1/validate.mjs
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import { validateReport as validateSafeRunnerReport } from '../../scripts/safe-runner/report.mjs';
+import {
+  COLD_RUNS, loadManifest, SCENARIOS, WARM_SAMPLES, WORKLOAD_SCHEMA,
+} from './contract.mjs';
+
+const exactKeys = (value, keys) => value && typeof value === 'object' && !Array.isArray(value)
+  && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+const integer = (value) => Number.isSafeInteger(value) && value >= 0;
+
+export function workloadRecordFromReport(report) {
+  const lines = String(report?.output?.stdout_tail || '').trim().split('\n').filter(Boolean).reverse();
+  for (const line of lines) {
+    try {
+      const value = JSON.parse(line);
+      if (value?.schema === WORKLOAD_SCHEMA) return value;
+    } catch {}
+  }
+  return null;
+}
+
+export function validateWorkloadRecord(record, { fixtureId = null, scenario = null } = {}) {
+  const errors = [];
+  const { manifest, digest } = loadManifest();
+  const fixture = manifest.fixtures.find((item) => item.id === record?.fixture?.id);
+  if (record?.schema !== WORKLOAD_SCHEMA) errors.push('record schema is invalid');
+  if (record?.manifest_digest !== digest) errors.push('record manifest digest is stale');
+  if (!fixture || fixture.commit !== record?.fixture?.commit || fixture.url !== record?.fixture?.url) {
+    errors.push('record fixture identity contradicts the manifest');
+  }
+  if (fixtureId && record?.fixture?.id !== fixtureId) errors.push('record fixture id contradicts the command');
+  if (!SCENARIOS.includes(record?.scenario) || (scenario && record?.scenario !== scenario)) {
+    errors.push('record scenario contradicts the command');
+  }
+  const repository = record?.repository;
+  if (!repository || repository.commit !== record?.fixture?.commit
+    || !integer(repository.tracked_files) || !integer(repository.tracked_bytes)
+    || !integer(repository.tracked_source_files) || !integer(repository.tracked_source_bytes)
+    || !integer(repository.tracked_source_loc) || !integer(repository.indexed_candidate_files)
+    || !integer(repository.indexed_candidate_bytes) || !Array.isArray(repository.exclusion_rules)
+    || typeof repository.indexed_paths_digest !== 'string') {
+    errors.push('record repository cardinality evidence is incomplete');
+  }
+  if (!record?.cleanup || record.cleanup.repository_removed !== true
+    || record.cleanup.socket_removed !== true || record.cleanup.lock_removed !== true) {
+    errors.push('record cleanup evidence is incomplete');
+  }
+  if (record?.classification === 'cold') {
+    if (!Array.isArray(record.samples) || record.samples.length !== COLD_RUNS
+      || record.statistics?.count !== COLD_RUNS || record.statistics?.p90 !== null
+      || record.statistics?.p95 !== null) errors.push('cold statistics are mislabeled or incomplete');
+  } else if (record?.classification === 'warm') {
+    if (!Array.isArray(record.samples) || record.samples.length !== WARM_SAMPLES
+      || record.statistics?.count !== WARM_SAMPLES || !integer(record.statistics?.p90)
+      || !integer(record.statistics?.p95) || record.warmups_excluded !== 1) {
+      errors.push('warm statistics are mislabeled or incomplete');
+    }
+  } else if (record?.classification === 'repeated-expensive') {
+    if (!Array.isArray(record.samples) || record.samples.length !== COLD_RUNS
+      || record.statistics?.p90 !== null || record.statistics?.p95 !== null
+      || typeof record.p95_omitted_reason !== 'string') {
+      errors.push('expensive repeated statistics must omit percentiles with a reason');
+    }
+  } else if (!['static', 'expected-cancellation'].includes(record?.classification)) {
+    errors.push('record classification is invalid');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateScenarioResult(result, artifactRoot) {
+  const errors = [];
+  if (!exactKeys(result, [
+    'schema', 'generated_at', 'status', 'fixture', 'scenario', 'measured_tier',
+    'workload', 'runs', 'limitations',
+  ]) || result.schema !== 'lamina.runtime-baseline-result/v1') {
+    errors.push('scenario result has an invalid top-level shape');
+  }
+  if (!['valid', 'refused', 'invalid'].includes(result?.status)) errors.push('scenario result status is invalid');
+  const tiers = result?.fixture?.id === 'large' ? ['small', 'medium', 'large']
+    : result?.fixture?.id === 'medium' ? ['small', 'medium'] : ['small'];
+  if (!Array.isArray(result?.runs) || result.runs.length < 1 || result.runs.length > tiers.length
+    || result.runs.some((run, index) => run.tier !== tiers[index])
+    || (result.status === 'valid' && result.runs.length !== tiers.length)) {
+    errors.push('scenario result lacks its exact sequential promotion chain');
+  }
+  for (const run of result?.runs || []) {
+    const file = path.resolve(artifactRoot, run.raw_report);
+    if (!file.startsWith(`${path.resolve(artifactRoot)}${path.sep}`)) {
+      errors.push(`${run.raw_report}: raw report escapes the artifact root`);
+      continue;
+    }
+    let report;
+    let bytes;
+    try {
+      bytes = fs.readFileSync(file);
+      report = JSON.parse(bytes.toString('utf8'));
+    } catch (error) {
+      errors.push(`${run.raw_report}: ${error.message}`);
+      continue;
+    }
+    if (crypto.createHash('sha256').update(bytes).digest('hex') !== run.raw_report_sha256) {
+      errors.push(`${run.raw_report}: raw report digest mismatch`);
+    }
+    const validation = validateSafeRunnerReport(report);
+    if (!validation.valid) errors.push(`${run.raw_report}: ${validation.errors.join('; ')}`);
+    if (report.outcome !== run.outcome || report.peaks.cgroup_memory_bytes !== run.peak_memory_bytes
+      || report.cleanup.descendants_remaining.length !== run.remaining_descendants
+      || report.cleanup.managed_paths_remaining.length !== run.remaining_managed_paths) {
+      errors.push(`${run.raw_report}: summarized safe-runner evidence contradicts raw JSON`);
+    }
+  }
+  if (result?.status === 'valid') {
+    const workload = validateWorkloadRecord(result.workload, {
+      fixtureId: result.fixture.id, scenario: result.scenario,
+    });
+    errors.push(...workload.errors);
+    if (result.runs.some((run) => run.outcome !== 'success'
+      || run.remaining_descendants !== 0 || run.remaining_managed_paths !== 0)) {
+      errors.push('valid result contains a failed or unclean safe-runner execution');
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}

--- a/benchmarks/runtime-baseline-v1/validate.mjs
+++ b/benchmarks/runtime-baseline-v1/validate.mjs
@@ -38,9 +38,16 @@ export function validateWorkloadRecord(record, { fixtureId = null, scenario = nu
   if (!repository || repository.commit !== record?.fixture?.commit
     || !integer(repository.tracked_files) || !integer(repository.tracked_bytes)
     || !integer(repository.tracked_source_files) || !integer(repository.tracked_source_bytes)
-    || !integer(repository.tracked_source_loc) || !integer(repository.indexed_candidate_files)
-    || !integer(repository.indexed_candidate_bytes) || !Array.isArray(repository.exclusion_rules)
-    || typeof repository.indexed_paths_digest !== 'string') {
+    || !integer(repository.tracked_source_loc) || !integer(repository.observation_indexed_files)
+    || !integer(repository.observation_indexed_bytes) || !integer(repository.retrieval_candidate_files)
+    || !integer(repository.retrieval_candidate_bytes)
+    || !((repository.retrieval_indexed_files === null
+      && repository.retrieval_indexed_bytes === null && repository.retrieval_source_chunks === null)
+      || (integer(repository.retrieval_indexed_files) && integer(repository.retrieval_indexed_bytes)
+        && integer(repository.retrieval_source_chunks)))
+    || !Array.isArray(repository.exclusion_rules)
+    || typeof repository.observation_paths_digest !== 'string'
+    || typeof repository.retrieval_paths_digest !== 'string') {
     errors.push('record repository cardinality evidence is incomplete');
   }
   if (!record?.cleanup || record.cleanup.repository_removed !== true
@@ -51,6 +58,10 @@ export function validateWorkloadRecord(record, { fixtureId = null, scenario = nu
     if (!Array.isArray(record.samples) || record.samples.length !== COLD_RUNS
       || record.statistics?.count !== COLD_RUNS || record.statistics?.p90 !== null
       || record.statistics?.p95 !== null) errors.push('cold statistics are mislabeled or incomplete');
+  } else if (record?.classification === 'cold-sample') {
+    if (!Array.isArray(record.samples) || record.samples.length !== 1 || record.statistics !== null) {
+      errors.push('cold sample must contain exactly one unaggregated measurement');
+    }
   } else if (record?.classification === 'warm') {
     if (!Array.isArray(record.samples) || record.samples.length !== WARM_SAMPLES
       || record.statistics?.count !== WARM_SAMPLES || !integer(record.statistics?.p90)
@@ -62,6 +73,13 @@ export function validateWorkloadRecord(record, { fixtureId = null, scenario = nu
       || record.statistics?.p90 !== null || record.statistics?.p95 !== null
       || typeof record.p95_omitted_reason !== 'string') {
       errors.push('expensive repeated statistics must omit percentiles with a reason');
+    }
+  } else if (record?.classification === 'steady-state') {
+    if (!Array.isArray(record.samples) || record.samples.length !== 10
+      || record.samples.some((sample, index) => sample?.index !== index || !integer(sample?.rss_bytes))
+      || record.statistics?.count !== 10 || record.statistics?.p90 !== null
+      || record.statistics?.p95 !== null || record.measurement_unit !== 'bytes') {
+      errors.push('steady-state RSS evidence is incomplete or mislabeled');
     }
   } else if (!['static', 'expected-cancellation'].includes(record?.classification)) {
     errors.push('record classification is invalid');
@@ -80,9 +98,13 @@ export function validateScenarioResult(result, artifactRoot) {
   if (!['valid', 'refused', 'invalid'].includes(result?.status)) errors.push('scenario result status is invalid');
   const tiers = result?.fixture?.id === 'large' ? ['small', 'medium', 'large']
     : result?.fixture?.id === 'medium' ? ['small', 'medium'] : ['small'];
-  if (!Array.isArray(result?.runs) || result.runs.length < 1 || result.runs.length > tiers.length
-    || result.runs.some((run, index) => run.tier !== tiers[index])
-    || (result.status === 'valid' && result.runs.length !== tiers.length)) {
+  const maximumTierSequence = [...tiers, tiers.at(-1), tiers.at(-1)];
+  const expectedValidTiers = result?.workload?.classification === 'cold'
+    ? maximumTierSequence : tiers;
+  if (!Array.isArray(result?.runs) || result.runs.length < 1
+    || result.runs.length > maximumTierSequence.length
+    || result.runs.some((run, index) => run.tier !== maximumTierSequence[index])
+    || (result.status === 'valid' && result.runs.length !== expectedValidTiers.length)) {
     errors.push('scenario result lacks its exact sequential promotion chain');
   }
   for (const run of result?.runs || []) {
@@ -105,6 +127,15 @@ export function validateScenarioResult(result, artifactRoot) {
     }
     const validation = validateSafeRunnerReport(report);
     if (!validation.valid) errors.push(`${run.raw_report}: ${validation.errors.join('; ')}`);
+    if (report.outcome === 'success') {
+      const rawWorkload = workloadRecordFromReport(report);
+      const rawValidation = validateWorkloadRecord(rawWorkload, {
+        fixtureId: result.fixture.id, scenario: result.scenario,
+      });
+      if (!rawValidation.valid) {
+        errors.push(`${run.raw_report}: raw workload: ${rawValidation.errors.join('; ')}`);
+      }
+    }
     if (report.outcome !== run.outcome || report.peaks.cgroup_memory_bytes !== run.peak_memory_bytes
       || report.cleanup.descendants_remaining.length !== run.remaining_descendants
       || report.cleanup.managed_paths_remaining.length !== run.remaining_managed_paths) {

--- a/benchmarks/runtime-baseline-v1/workload.mjs
+++ b/benchmarks/runtime-baseline-v1/workload.mjs
@@ -7,9 +7,11 @@ import { once } from 'node:events';
 import { fileURLToPath } from 'node:url';
 import {
   graphRequest,
+  graphdIdentity,
   stopIncompatibleServer,
 } from '../../packages/cli/lib/graph-runtime/client.mjs';
 import { runtimePaths } from '../../packages/cli/lib/graph-runtime/util.mjs';
+import { ensureRetrieval } from '../../packages/cli/lib/retrieval-runtime/process.mjs';
 import { assertSafeRunnerContext } from '../../packages/cli/lib/safe-runner-context.mjs';
 import {
   assertScenario,
@@ -199,7 +201,8 @@ function ignored(relative, exclusions) {
     || pieces.includes('coverage') || pieces.some((piece) => /^\.venv/.test(piece))) return true;
   return exclusions.some((rule) => {
     const normalized = rule.replace(/\*$/, '');
-    return relative === normalized || relative.startsWith(`${normalized}/`);
+    return relative === normalized || relative.startsWith(`${normalized}/`)
+      || (rule.endsWith('*') && relative.startsWith(normalized));
   });
 }
 
@@ -213,6 +216,10 @@ function repositoryMetadata(repository, manifest, fixture) {
   let indexedBytes = 0;
   let indexedFiles = 0;
   const indexed = [];
+  let retrievalBytes = 0;
+  let retrievalFiles = 0;
+  const retrievalPaths = [];
+  const retrievalExtensions = new Set(manifest.retrieval_extensions);
   for (const relative of tracked) {
     const file = path.join(repository, relative);
     let stat;
@@ -225,6 +232,14 @@ function repositoryMetadata(repository, manifest, fixture) {
       indexed.push(relative);
     }
     const extension = path.extname(relative).toLowerCase();
+    if (retrievalExtensions.has(extension) && stat.size <= manifest.retrieval_max_file_bytes) {
+      try {
+        new TextDecoder('utf-8', { fatal: true }).decode(fs.readFileSync(file));
+        retrievalFiles += 1;
+        retrievalBytes += stat.size;
+        retrievalPaths.push(relative);
+      } catch {}
+    }
     if (sourceExtensions.has(extension) || SOURCE_NAMES.has(path.basename(relative))) {
       sourceFiles += 1;
       sourceBytes += stat.size;
@@ -237,17 +252,72 @@ function repositoryMetadata(repository, manifest, fixture) {
   if (sourceLoc < fixture.source_loc.minimum || sourceLoc > fixture.source_loc.maximum) {
     fail('fixture source LOC is outside its pinned class', { sourceLoc, range: fixture.source_loc });
   }
-  return {
+  const result = {
     commit: fixture.commit,
     tracked_files: tracked.length,
     tracked_bytes: trackedBytes,
     tracked_source_files: sourceFiles,
     tracked_source_bytes: sourceBytes,
     tracked_source_loc: sourceLoc,
-    indexed_candidate_files: indexedFiles,
-    indexed_candidate_bytes: indexedBytes,
+    observation_indexed_files: indexedFiles,
+    observation_indexed_bytes: indexedBytes,
+    retrieval_candidate_files: retrievalFiles,
+    retrieval_candidate_bytes: retrievalBytes,
+    retrieval_indexed_files: null,
+    retrieval_indexed_bytes: null,
+    retrieval_source_chunks: null,
     exclusion_rules: manifest.exclusions,
-    indexed_paths_digest: sha256(indexed.join('\n')),
+    observation_paths_digest: sha256(indexed.join('\n')),
+    retrieval_paths_digest: sha256(retrievalPaths.join('\n')),
+  };
+  Object.defineProperty(result, '_retrieval_paths', { value: retrievalPaths });
+  return result;
+}
+
+async function recordRetrievalInventory(repository, metadata) {
+  const prepared = await ensureRetrieval(repository);
+  const snapshot = prepared.snapshot;
+  const status = await graphRequest('retrieval.status', {
+    identity: snapshot.identity,
+    graph_version: snapshot.graph_version,
+    source_revision: snapshot.source_revision,
+    repository_revision: snapshot.repository_revision,
+    branch: snapshot.branch,
+    worktree: snapshot.worktree,
+    model_digest: snapshot.model_digest,
+    schema_version: snapshot.schema_version,
+    include_documents: true,
+  }, repository);
+  if (!status.fresh || status.counts?.committed !== status.counts?.expected) {
+    fail('retrieval inventory is not a complete current generation', { status: compactDiagnostics(status) });
+  }
+  const sourceKeys = Object.keys(status.documents || {}).filter((key) => key.startsWith('source:'));
+  if (sourceKeys.length !== status.counts.source_chunks) {
+    fail('retrieval source chunk count contradicts the active generation', {
+      document_source_keys: sourceKeys.length,
+      status_source_chunks: status.counts.source_chunks,
+    });
+  }
+  const actualPaths = new Set();
+  for (const key of sourceKeys) {
+    const match = /^source:(.*):(?:<module>|[A-Za-z_$][A-Za-z0-9_$]*):\d+:\d+$/.exec(key);
+    if (!match) fail('active retrieval source key has an unknown shape', { key });
+    actualPaths.add(match[1]);
+  }
+  const candidatePaths = new Set(metadata._retrieval_paths);
+  const unexpected = [...actualPaths].filter((item) => !candidatePaths.has(item));
+  if (unexpected.length) fail('active retrieval generation contains non-candidate paths', { unexpected: unexpected.slice(0, 10) });
+  metadata.retrieval_indexed_files = actualPaths.size;
+  metadata.retrieval_indexed_bytes = [...actualPaths].reduce(
+    (sum, relative) => sum + fs.statSync(path.join(repository, relative)).size,
+    0,
+  );
+  metadata.retrieval_source_chunks = sourceKeys.length;
+  return {
+    fresh: status.fresh,
+    counts: status.counts,
+    indexed_files: metadata.retrieval_indexed_files,
+    indexed_bytes: metadata.retrieval_indexed_bytes,
   };
 }
 
@@ -350,17 +420,23 @@ function timeSync(callback) {
 
 async function disposeRepository(repository) {
   const paths = runtimePaths(repository);
-  await stopIncompatibleServer(paths).catch(() => {});
+  await stopIncompatibleServer(paths);
+  const socketRemoved = !fs.existsSync(paths.socket);
+  const lockRemoved = !fs.existsSync(paths.lock);
+  if (!socketRemoved || !lockRemoved) {
+    fail('graphd shutdown left runtime objects', { socket_removed: socketRemoved, lock_removed: lockRemoved });
+  }
   fs.rmSync(repository, { recursive: true, force: false });
   return {
     repository_removed: !fs.existsSync(repository),
-    socket_removed: !fs.existsSync(paths.socket),
-    lock_removed: !fs.existsSync(paths.lock),
+    socket_removed: socketRemoved,
+    lock_removed: lockRemoved,
   };
 }
 
 function compactDiagnostics(value) {
   return {
+    schema: value?.schema || null,
     backend: value?.backend || null,
     mode: value?.mode || null,
     generation: value?.generation || value?.status?.generation || null,
@@ -370,10 +446,35 @@ function compactDiagnostics(value) {
     counts: value?.counts || value?.status?.counts || null,
     freshness: value?.freshness || value?.status?.freshness || null,
     index_digest: value?.index_digest || value?.status?.index_digest || null,
+    retrieval_generation: value?.retrieval?.generation || null,
+    retrieval_outcome: value?.retrieval?.outcome || null,
+    explicit_workflow_bypass: value?.retrieval?.explicit_workflow_bypass ?? null,
+    degradation: value?.retrieval?.degradation ?? null,
+    selected_workflow_ids: value?.retrieval?.selected_workflow_ids || null,
+    source_chunk_count: Array.isArray(value?.retrieval?.source_chunks) ? value.retrieval.source_chunks.length : null,
+    source_chunk_paths: Array.isArray(value?.retrieval?.source_chunks)
+      ? [...new Set(value.retrieval.source_chunks.map((item) => item.path).filter(Boolean))].slice(0, 5) : null,
     packet_id: value?.packet_id || null,
     obligation_count: Array.isArray(value?.obligations) ? value.obligations.length : null,
     experience_case_count: Array.isArray(value?.experience_cases) ? value.experience_cases.length : null,
   };
+}
+
+function assertUsefulPacket(packet, expectedWorkflow) {
+  const retrieval = packet?.retrieval;
+  if (packet?.schema !== 'lamina.implementation-packet/v5'
+    || !Array.isArray(packet.obligations) || packet.obligations.length === 0
+    || retrieval?.outcome !== 'selected'
+    || retrieval?.explicit_workflow_bypass !== false
+    || retrieval?.degradation !== null
+    || JSON.stringify(retrieval?.selected_workflow_ids) !== JSON.stringify([expectedWorkflow])
+    || !Array.isArray(retrieval?.source_chunks) || retrieval.source_chunks.length === 0
+    || !retrieval.source_chunks.some((item) => typeof item?.path === 'string' && item.path.length > 0)) {
+    fail('work prepare did not produce a correct useful packet from the real retrieval path', {
+      diagnostics: compactDiagnostics(packet),
+    });
+  }
+  return packet;
 }
 
 function changeFiles(repository, count) {
@@ -383,7 +484,10 @@ function changeFiles(repository, count) {
     .sort((left, right) => fs.statSync(path.join(repository, left)).size - fs.statSync(path.join(repository, right)).size)
     .slice(0, count);
   if (candidates.length !== count) fail('fixture lacks enough mutable source files');
-  for (const relative of candidates) fs.appendFileSync(path.join(repository, relative), '\n// lamina runtime baseline bounded change\n');
+  for (const relative of candidates) {
+    const marker = path.extname(relative).toLowerCase() === '.py' ? '#' : '//';
+    fs.appendFileSync(path.join(repository, relative), `\n${marker} lamina runtime baseline bounded change\n`);
+  }
   git(repository, ['add', '--', ...candidates]);
   git(repository, ['-c', 'user.name=Lamina Baseline', '-c', 'user.email=baseline@lamina.invalid', 'commit', '-m', `baseline ${count}-file change`]);
   return candidates;
@@ -398,28 +502,54 @@ async function runSample({ fixture, manifest, source, scenario, index }) {
   try {
     if (!['doctor-status-startup'].includes(scenario)) seeded = await seedGraph(repository);
     if (scenario === 'doctor-status-startup') {
-      measurement = timeSync(() => ({
-        doctor: cli(repository, ['doctor', '--json']),
-        status: cli(repository, ['graph', 'status']),
-      }));
-      diagnostics = { graph_version: measurement.value.status.graph_version || null };
+      const started = process.hrtime.bigint();
+      const doctor = timeSync(() => cli(repository, ['doctor', '--json']));
+      const status = timeSync(() => cli(repository, ['graph', 'status']));
+      measurement = {
+        wall_time_ns: Number(process.hrtime.bigint() - started),
+        value: { doctor: doctor.value, status: status.value },
+      };
+      diagnostics = {
+        doctor_wall_time_ns: doctor.wall_time_ns,
+        status_and_graphd_startup_wall_time_ns: status.wall_time_ns,
+        graph_version: status.value.graph_version || null,
+      };
     } else if (scenario === 'initial-observation') {
       measurement = timeSync(() => cli(repository, ['graph', 'observe']));
       diagnostics = compactDiagnostics(measurement.value);
-      if (diagnostics.source_key_count !== metadata.indexed_candidate_files) {
+      if (diagnostics.source_key_count !== metadata.observation_indexed_files) {
         fail('observation indexed count contradicts the pinned candidate set', { diagnostics, metadata });
       }
     } else if (scenario === 'initial-retrieval-readiness') {
+      cli(repository, ['graph', 'observe']);
       measurement = timeSync(() => cli(repository, ['context', 'rebuild']));
-      diagnostics = compactDiagnostics(measurement.value);
+      diagnostics = {
+        ...compactDiagnostics(measurement.value),
+        inventory: await recordRetrievalInventory(repository, metadata),
+      };
     } else if (scenario === 'first-useful-preparation') {
+      cli(repository, ['graph', 'observe']);
       const output = path.join(repository, '.git', 'lamina', 'work', 'packet.json');
-      measurement = timeSync(() => cli(repository, ['work', 'prepare', '--request-file', seeded.request, '--workflow', seeded.workflow, '--output', output]));
-      diagnostics = compactDiagnostics(measurement.value);
+      measurement = timeSync(() => assertUsefulPacket(
+        cli(repository, ['work', 'prepare', '--request-file', seeded.request, '--output', output]),
+        seeded.workflow,
+      ));
+      diagnostics = {
+        ...compactDiagnostics(measurement.value),
+        inventory: await recordRetrievalInventory(repository, metadata),
+      };
     } else if (scenario === 'one-file-change' || scenario === 'multi-file-change') {
       const changed = changeFiles(repository, scenario === 'one-file-change' ? 1 : 5);
-      measurement = timeSync(() => cli(repository, ['graph', 'observe']));
-      diagnostics = { ...compactDiagnostics(measurement.value), changed_files: changed };
+      measurement = timeSync(() => ({
+        observation: cli(repository, ['graph', 'observe']),
+        retrieval: cli(repository, ['context', 'rebuild']),
+      }));
+      diagnostics = {
+        observation: compactDiagnostics(measurement.value.observation),
+        retrieval: compactDiagnostics(measurement.value.retrieval),
+        changed_files: changed,
+        inventory: await recordRetrievalInventory(repository, metadata),
+      };
     } else if (scenario === 'full-derived-state-rebuild') {
       cli(repository, ['graph', 'observe']);
       cli(repository, ['context', 'rebuild']);
@@ -430,20 +560,27 @@ async function runSample({ fixture, manifest, source, scenario, index }) {
       diagnostics = {
         observation: compactDiagnostics(measurement.value.observation),
         retrieval: compactDiagnostics(measurement.value.retrieval),
+        inventory: await recordRetrievalInventory(repository, metadata),
       };
     } else if (scenario === 'post-command-idle-rss') {
-      const status = cli(repository, ['graph', 'status']);
-      const pid = status.pid || runtimePaths(repository).daemon?.pid;
+      cli(repository, ['graph', 'status']);
+      const pid = (await graphdIdentity(repository)).pid;
       const readRss = () => {
         try {
           const line = fs.readFileSync(`/proc/${pid}/status`, 'utf8').split('\n').find((item) => item.startsWith('VmRSS:'));
           return Number(line?.match(/\d+/)?.[0] || 0) * 1024;
         } catch { return 0; }
       };
-      const before = readRss();
-      measurement = timeSync(() => run('/bin/sh', ['-c', 'read _ || exit 0'], { input: '', timeout: 5_000 }));
-      await new Promise((resolve) => setTimeout(resolve, 2_000));
-      diagnostics = { graphd_pid: pid || null, idle_rss_before_bytes: before, idle_rss_after_bytes: readRss(), idle_window_ms: 2000 };
+      const started = process.hrtime.bigint();
+      const rssSamples = [];
+      for (let sample = 0; sample < 10; sample += 1) {
+        if (sample) await new Promise((resolve) => setTimeout(resolve, 1_000));
+        const rssBytes = readRss();
+        if (!rssBytes) fail('graphd exited during the idle RSS window', { pid, sample });
+        rssSamples.push({ index: sample, elapsed_ms: sample * 1000, rss_bytes: rssBytes });
+      }
+      measurement = { wall_time_ns: Number(process.hrtime.bigint() - started), value: null };
+      diagnostics = { graphd_pid: pid || null, idle_rss_samples: rssSamples, idle_window_ms: 9000 };
     } else {
       fail('scenario is not a cold sample', { scenario });
     }
@@ -464,30 +601,43 @@ async function warmScenario({ fixture, manifest, source, scenario }) {
   const repository = freshRepository(source, fixture, scenario, 0);
   const metadata = repositoryMetadata(repository, manifest, fixture);
   const seeded = await seedGraph(repository);
+  cli(repository, ['graph', 'observe']);
   const samples = [];
   const diagnostics = [];
-  const total = scenario === 'warm-preparation' ? WARMUP_SAMPLES + WARM_SAMPLES : COLD_RUNS;
+  const total = WARMUP_SAMPLES + WARM_SAMPLES;
+  let noOpIdentity = null;
   try {
     for (let index = 0; index < total; index += 1) {
       let measured;
-      if (scenario === 'warm-preparation') {
-        const output = path.join(repository, '.git', 'lamina', 'work', `packet-${index}.json`);
-        measured = timeSync(() => cli(repository, ['work', 'prepare', '--request-file', seeded.request, '--workflow', seeded.workflow, '--output', output]));
-      } else {
-        measured = timeSync(() => cli(repository, ['graph', 'observe']));
+      const output = path.join(repository, '.git', 'lamina', 'work', `packet-${index}.json`);
+      measured = timeSync(() => assertUsefulPacket(
+        cli(repository, ['work', 'prepare', '--request-file', seeded.request, '--output', output]),
+        seeded.workflow,
+      ));
+      if (scenario === 'noop-synchronization') {
+        const current = {
+          generation: measured.value.retrieval.generation,
+          index_digest: measured.value.retrieval.index_digest,
+          source_revision: measured.value.source.source_revision,
+        };
+        noOpIdentity ||= current;
+        if (JSON.stringify(current) !== JSON.stringify(noOpIdentity)) {
+          fail('no-op synchronization changed retrieval identity', { expected: noOpIdentity, actual: current });
+        }
       }
-      if (scenario !== 'warm-preparation' || index >= WARMUP_SAMPLES) samples.push(measured.wall_time_ns);
+      if (index >= WARMUP_SAMPLES) samples.push(measured.wall_time_ns);
       diagnostics.push(compactDiagnostics(measured.value));
     }
+    const inventory = await recordRetrievalInventory(repository, metadata);
     return {
       samples,
-      statistics: summarizeNanoseconds(samples, scenario === 'warm-preparation'),
-      classification: scenario === 'warm-preparation' ? 'warm' : 'repeated-expensive',
-      warmups_excluded: scenario === 'warm-preparation' ? WARMUP_SAMPLES : 0,
-      p95_omitted_reason: scenario === 'noop-synchronization'
-        ? 'A no-op observation still scans the real repository; 30 repetitions are materially expensive at medium and large scale.' : null,
+      statistics: summarizeNanoseconds(samples, true),
+      classification: 'warm',
+      warmups_excluded: WARMUP_SAMPLES,
+      p95_omitted_reason: null,
+      no_op_identity: noOpIdentity,
       repository: metadata,
-      diagnostics: diagnostics.slice(-3),
+      diagnostics: [...diagnostics.slice(-3), { inventory }],
       cleanup: await disposeRepository(repository),
     };
   } catch (error) {
@@ -508,7 +658,20 @@ async function cancellationScenario({ fixture, manifest, source, scenario }) {
   child.stdout.on('data', (chunk) => { stdout = `${stdout}${chunk}`.slice(-4000); });
   child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-4000); });
   await new Promise((resolve) => setTimeout(resolve, 2_000));
-  try { process.kill(-child.pid, 'SIGTERM'); } catch { try { child.kill('SIGTERM'); } catch {} }
+  if (child.exitCode !== null || child.signalCode !== null) {
+    await disposeRepository(repository).catch(() => {});
+    fail('live observation exited before cancellation could be exercised', {
+      exit_code: child.exitCode, exit_signal: child.signalCode,
+    });
+  }
+  const daemon = await graphdIdentity(repository);
+  if (!daemon?.pid) {
+    try { process.kill(-child.pid, 'SIGKILL'); } catch {}
+    await once(child, 'exit').catch(() => {});
+    await disposeRepository(repository).catch(() => {});
+    fail('cancellation scenario did not prove graphd startup');
+  }
+  try { process.kill(-child.pid, 'SIGINT'); } catch { try { child.kill('SIGINT'); } catch {} }
   const [code, signal] = await Promise.race([
     once(child, 'exit'),
     new Promise((resolve) => setTimeout(() => resolve([null, 'TIMEOUT']), 10_000)),
@@ -516,6 +679,10 @@ async function cancellationScenario({ fixture, manifest, source, scenario }) {
   if (signal === 'TIMEOUT') {
     try { process.kill(-child.pid, 'SIGKILL'); } catch {}
     await once(child, 'exit').catch(() => {});
+    await disposeRepository(repository).catch(() => {});
+    fail('live observation did not stop within the cancellation deadline', {
+      graphd_pid: daemon.pid, stdout_tail: stdout.slice(-512), stderr_tail: stderr.slice(-512),
+    });
   }
   const cleanup = await disposeRepository(repository);
   return {
@@ -523,7 +690,10 @@ async function cancellationScenario({ fixture, manifest, source, scenario }) {
     statistics: null,
     classification: 'expected-cancellation',
     repository: metadata,
-    diagnostics: { exit_code: code, exit_signal: signal, stdout_tail: stdout, stderr_tail: stderr },
+    diagnostics: {
+      graphd_pid: daemon.pid, exit_code: code, exit_signal: signal,
+      stdout_tail: stdout.slice(-512), stderr_tail: stderr.slice(-512),
+    },
     cleanup,
   };
 }
@@ -550,23 +720,28 @@ async function execute(fixtureId, scenario, modelFile, workerFile) {
     payload = await warmScenario({ fixture, manifest, source, scenario });
   } else if (scenario === 'cancellation-shutdown-cleanup') {
     payload = await cancellationScenario({ fixture, manifest, source, scenario });
-  } else {
-    const samples = [];
-    for (let index = 0; index < COLD_RUNS; index += 1) {
-      samples.push(await runSample({ fixture, manifest, source, scenario, index }));
-    }
-    const latencies = samples.map((sample) => sample.wall_time_ns);
+  } else if (scenario === 'post-command-idle-rss') {
+    const sample = await runSample({ fixture, manifest, source, scenario, index: 0 });
+    const rssSamples = sample.diagnostics.idle_rss_samples;
     payload = {
-      samples: samples.map(({ repository: _repository, ...sample }) => sample),
-      statistics: summarizeNanoseconds(latencies, false),
-      classification: 'cold',
-      repository: samples[0].repository,
-      diagnostics: samples.map((sample) => sample.diagnostics),
-      cleanup: {
-        repository_removed: samples.every((sample) => sample.cleanup.repository_removed),
-        socket_removed: samples.every((sample) => sample.cleanup.socket_removed),
-        lock_removed: samples.every((sample) => sample.cleanup.lock_removed),
-      },
+      samples: rssSamples,
+      statistics: summarizeNanoseconds(rssSamples.map((item) => item.rss_bytes), false),
+      classification: 'steady-state',
+      measurement_unit: 'bytes',
+      repository: sample.repository,
+      diagnostics: [sample.diagnostics],
+      cleanup: sample.cleanup,
+    };
+  } else {
+    const sample = await runSample({ fixture, manifest, source, scenario, index: 0 });
+    const { repository, ...boundedSample } = sample;
+    payload = {
+      samples: [boundedSample],
+      statistics: null,
+      classification: 'cold-sample',
+      repository,
+      diagnostics: [sample.diagnostics],
+      cleanup: sample.cleanup,
     };
   }
   const record = {

--- a/benchmarks/runtime-baseline-v1/workload.mjs
+++ b/benchmarks/runtime-baseline-v1/workload.mjs
@@ -1,0 +1,606 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import {
+  graphRequest,
+  stopIncompatibleServer,
+} from '../../packages/cli/lib/graph-runtime/client.mjs';
+import { runtimePaths } from '../../packages/cli/lib/graph-runtime/util.mjs';
+import { assertSafeRunnerContext } from '../../packages/cli/lib/safe-runner-context.mjs';
+import {
+  assertScenario,
+  COLD_RUNS,
+  fixtureById,
+  loadManifest,
+  MAX_WORKLOAD_OUTPUT_BYTES,
+  SCENARIOS,
+  sha256,
+  summarizeNanoseconds,
+  WARM_SAMPLES,
+  WARMUP_SAMPLES,
+  WORKLOAD_SCHEMA,
+} from './contract.mjs';
+
+assertSafeRunnerContext('real-repository runtime baseline');
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY = path.resolve(HERE, '../..');
+const CLI = path.join(REPOSITORY, 'packages/cli/bin/lamina.mjs');
+const PACKAGE_ROOT = path.join(REPOSITORY, 'packages/cli');
+const MARKER_SCHEMA = 'lamina.runtime-baseline-scratch/v1';
+const MAX_CHILD_OUTPUT = 8 * 1024 * 1024;
+const SOURCE_NAMES = new Set(['package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml']);
+
+const runnerTemporaryRoot = path.resolve(process.env.LAMINA_SAFE_RUNNER_TEMP_DIR || '');
+if (!process.env.LAMINA_SAFE_RUNNER_TEMP_DIR || !path.isAbsolute(runnerTemporaryRoot)) {
+  throw new Error('runtime baseline requires the safe runner private temporary authority');
+}
+const baselineRoot = path.join(runnerTemporaryRoot, 'runtime-baseline-v1');
+const markerFile = path.join(baselineRoot, '.lamina-runtime-baseline-owner.json');
+let runtimeInputs = null;
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function fail(message, details = {}) {
+  const error = new Error(message);
+  error.details = details;
+  throw error;
+}
+
+function ensureOwnedRoot() {
+  fs.mkdirSync(baselineRoot, { recursive: true, mode: 0o700 });
+  if (!fs.existsSync(markerFile)) {
+    const entries = fs.readdirSync(baselineRoot);
+    if (entries.length) fail('baseline scratch lacks its ownership marker', { entries });
+    fs.writeFileSync(markerFile, stableJson({
+      schema: MARKER_SCHEMA,
+      root: baselineRoot,
+      nonce: crypto.randomUUID(),
+      owned_entries: ['assets', 'sources', 'runs'],
+    }), { flag: 'wx', mode: 0o600 });
+  }
+  const marker = JSON.parse(fs.readFileSync(markerFile, 'utf8'));
+  if (marker.schema !== MARKER_SCHEMA || marker.root !== baselineRoot
+    || !Array.isArray(marker.owned_entries)
+    || marker.owned_entries.join(',') !== 'assets,sources,runs') {
+    fail('baseline scratch ownership marker is invalid');
+  }
+  for (const name of marker.owned_entries) fs.mkdirSync(path.join(baselineRoot, name), { recursive: true, mode: 0o700 });
+  return marker;
+}
+
+function cleanupOwnedRoot() {
+  if (!fs.existsSync(baselineRoot)) return { removed: false, already_absent: true };
+  const marker = JSON.parse(fs.readFileSync(markerFile, 'utf8'));
+  if (marker.schema !== MARKER_SCHEMA || marker.root !== baselineRoot) {
+    fail('baseline cleanup requires its exact ownership marker');
+  }
+  const allowed = new Set([path.basename(markerFile), ...marker.owned_entries]);
+  const foreign = fs.readdirSync(baselineRoot).filter((name) => !allowed.has(name));
+  if (foreign.length) fail('baseline cleanup refuses foreign entries', { foreign });
+  const quarantine = `${baselineRoot}.quarantine-${crypto.randomUUID()}`;
+  fs.renameSync(baselineRoot, quarantine);
+  fs.rmSync(quarantine, { recursive: true, force: false });
+  if (fs.existsSync(baselineRoot) || fs.existsSync(quarantine)) fail('baseline cleanup was incomplete');
+  return { removed: true, already_absent: false };
+}
+
+function childEnvironment(extra = {}) {
+  const assets = path.join(baselineRoot, 'assets');
+  return {
+    ...process.env,
+    LAMINA_RETRIEVAL_MODEL_PATH: runtimeInputs?.model || '',
+    LAMINA_RETRIEVAL_RUNTIME: path.join(assets, 'retrieval-runtime'),
+    ...extra,
+  };
+}
+
+function run(command, args, { cwd = REPOSITORY, env = childEnvironment(), input = null,
+  allowFailure = false, timeout = 20 * 60_000 } = {}) {
+  const result = spawnSync(command, args, {
+    cwd, env, input, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    timeout, maxBuffer: MAX_CHILD_OUTPUT,
+  });
+  if (result.error) throw result.error;
+  if (!allowFailure && result.status !== 0) {
+    fail(`child command failed: ${path.basename(command)} ${args.slice(0, 4).join(' ')}`, {
+      status: result.status,
+      signal: result.signal || null,
+      stdout_tail: String(result.stdout || '').slice(-4000),
+      stderr_tail: String(result.stderr || '').slice(-4000),
+    });
+  }
+  return result;
+}
+
+function git(cwd, args, options = {}) {
+  return run('git', [
+    '-c', 'core.hooksPath=/dev/null',
+    '-c', 'protocol.file.allow=always',
+    ...args,
+  ], { cwd, ...options });
+}
+
+function assertPinnedInput(file, expected, label) {
+  const absolute = path.resolve(file);
+  const stat = fs.lstatSync(absolute);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== expected.bytes) {
+    fail(`${label} is not the pinned physical input`, { file: absolute });
+  }
+  const bytes = fs.readFileSync(absolute);
+  if (sha256(bytes) !== expected.sha256) fail(`${label} checksum does not match the manifest`);
+  return absolute;
+}
+
+function prepareRuntimeAssets(manifest) {
+  const assets = path.join(baselineRoot, 'assets');
+  const worker = runtimeInputs.worker;
+  const runtime = path.join(assets, 'retrieval-runtime');
+  const runtimeManifest = path.join(runtime, 'asset-manifest.json');
+  if (!fs.existsSync(runtimeManifest)) {
+    run(worker, ['retrieval', 'extract-assets', '--destination', runtime], { env: childEnvironment() });
+  }
+  return footprint(assets, runtimeInputs);
+}
+
+function physicalFiles(root) {
+  const output = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(full);
+      else if (entry.isFile()) output.push(full);
+    }
+  };
+  visit(root);
+  return output;
+}
+
+function footprint(assets, inputs) {
+  const assetFiles = physicalFiles(assets);
+  const sourceFiles = physicalFiles(PACKAGE_ROOT).filter((file) => !file.includes(`${path.sep}node_modules${path.sep}`));
+  const summarize = (files) => ({
+    files: files.length,
+    bytes: files.reduce((sum, file) => sum + fs.statSync(file).size, 0),
+  });
+  return {
+    source_cli: summarize(sourceFiles),
+    prepared_assets: summarize(assetFiles),
+    sealed_model: { files: 1, bytes: fs.statSync(inputs.model).size },
+    sealed_worker: { files: 1, bytes: fs.statSync(inputs.worker).size },
+  };
+}
+
+function ensureSource(fixture) {
+  const source = path.join(baselineRoot, 'sources', fixture.id);
+  if (!fs.existsSync(path.join(source, '.git'))) {
+    fs.rmSync(source, { recursive: true, force: true });
+    git(baselineRoot, ['clone', '--filter=blob:none', '--no-checkout', fixture.url, source], {
+      timeout: 20 * 60_000,
+    });
+    git(source, ['checkout', '--detach', fixture.commit], { timeout: 20 * 60_000 });
+  }
+  const head = git(source, ['rev-parse', 'HEAD']).stdout.trim();
+  const dirty = git(source, ['status', '--porcelain=v1', '-z', '--untracked-files=all']).stdout;
+  if (head !== fixture.commit || dirty.length) fail('pinned fixture source changed', { head, dirty: dirty.length });
+  return source;
+}
+
+function ignored(relative, exclusions) {
+  const pieces = relative.split('/');
+  if (pieces.includes('.git') || pieces.includes('node_modules') || pieces.includes('__pycache__')
+    || pieces.includes('.next') || pieces.includes('dist') || pieces.includes('build')
+    || pieces.includes('coverage') || pieces.some((piece) => /^\.venv/.test(piece))) return true;
+  return exclusions.some((rule) => {
+    const normalized = rule.replace(/\*$/, '');
+    return relative === normalized || relative.startsWith(`${normalized}/`);
+  });
+}
+
+function repositoryMetadata(repository, manifest, fixture) {
+  const tracked = git(repository, ['ls-files', '-z']).stdout.split('\0').filter(Boolean);
+  const sourceExtensions = new Set(manifest.source_extensions);
+  let trackedBytes = 0;
+  let sourceBytes = 0;
+  let sourceLoc = 0;
+  let sourceFiles = 0;
+  let indexedBytes = 0;
+  let indexedFiles = 0;
+  const indexed = [];
+  for (const relative of tracked) {
+    const file = path.join(repository, relative);
+    let stat;
+    try { stat = fs.statSync(file); } catch { continue; }
+    if (!stat.isFile()) continue;
+    trackedBytes += stat.size;
+    if (!ignored(relative, manifest.exclusions)) {
+      indexedFiles += 1;
+      indexedBytes += stat.size;
+      indexed.push(relative);
+    }
+    const extension = path.extname(relative).toLowerCase();
+    if (sourceExtensions.has(extension) || SOURCE_NAMES.has(path.basename(relative))) {
+      sourceFiles += 1;
+      sourceBytes += stat.size;
+      if (stat.size <= 4 * 1024 * 1024) {
+        const text = fs.readFileSync(file, 'utf8');
+        sourceLoc += text.split(/\r?\n/).filter((line) => line.trim()).length;
+      }
+    }
+  }
+  if (sourceLoc < fixture.source_loc.minimum || sourceLoc > fixture.source_loc.maximum) {
+    fail('fixture source LOC is outside its pinned class', { sourceLoc, range: fixture.source_loc });
+  }
+  return {
+    commit: fixture.commit,
+    tracked_files: tracked.length,
+    tracked_bytes: trackedBytes,
+    tracked_source_files: sourceFiles,
+    tracked_source_bytes: sourceBytes,
+    tracked_source_loc: sourceLoc,
+    indexed_candidate_files: indexedFiles,
+    indexed_candidate_bytes: indexedBytes,
+    exclusion_rules: manifest.exclusions,
+    indexed_paths_digest: sha256(indexed.join('\n')),
+  };
+}
+
+function freshRepository(source, fixture, scenario, index) {
+  const parent = path.join(baselineRoot, 'runs', fixture.id, scenario);
+  fs.mkdirSync(parent, { recursive: true, mode: 0o700 });
+  const repository = path.join(parent, `sample-${index}`);
+  fs.rmSync(repository, { recursive: true, force: true });
+  git(parent, ['clone', '--shared', '--no-checkout', source, repository]);
+  git(repository, ['checkout', '--detach', fixture.commit]);
+  return repository;
+}
+
+function cli(repository, args, options = {}) {
+  const result = run(process.execPath, [CLI, ...args], { cwd: repository, env: childEnvironment(), ...options });
+  try { return JSON.parse(result.stdout); } catch {
+    fail('Lamina CLI returned invalid JSON', { args, stdout_tail: result.stdout.slice(-2000) });
+  }
+}
+
+async function seedGraph(repository) {
+  const workflow = 'workflow.baseline';
+  const operation = 'operation.baseline.inspect';
+  const actor = 'actor.baseline.maintainer';
+  const persona = 'persona.baseline.maintainer';
+  const invariant = 'invariant.baseline.preserve-source';
+  const scenario = 'scenario.baseline.failed-change';
+  const resources = [
+    { id: workflow, kind: 'workflow', alias: 'baseline-change', data: { name: 'Implement a bounded repository change', objective: 'Prepare one safe, reviewable repository change.' } },
+    { id: operation, kind: 'operation', data: { name: 'Inspect and change one source file', description: 'Inspect current source, make a bounded change, and preserve repository behavior.' } },
+    { id: actor, kind: 'actor', data: { name: 'Repository maintainer' } },
+    { id: persona, kind: 'persona', data: { name: 'Repository maintainer', goal: 'Prepare a bounded source change without losing existing behavior.' } },
+    { id: invariant, kind: 'invariant', data: { name: 'Existing source behavior remains preserved outside the requested change.' } },
+    { id: scenario, kind: 'scenario', data: { name: 'The proposed change cannot be prepared safely.' } },
+  ];
+  const session = await graphRequest('session.start', {}, repository);
+  for (const resource of resources) await graphRequest('resource.propose', { session: session.id, resource }, repository);
+  for (const statement of [
+    { subject: workflow, predicate: 'lamina:hasStep', object: operation, qualifiers: { position: 1 } },
+    { subject: actor, predicate: 'lamina:authorizedFor', object: operation },
+    { subject: persona, predicate: 'lamina:canAssume', object: actor },
+    { subject: workflow, predicate: 'lamina:constrainedBy', object: invariant },
+    { subject: workflow, predicate: 'lamina:hasScenario', object: scenario },
+  ]) await graphRequest('statement.propose', { session: session.id, statement }, repository);
+  await graphRequest('session.publish', { id: session.id }, repository);
+  const task = await graphRequest('design.walk.prepare', {
+    workflow, persona, request: 'Prepare one bounded source change.',
+  }, repository);
+  await graphRequest('design.walk.record', {
+    task,
+    result: {
+      schema: 'lamina.persona-walk/v1', task_id: task.task_id,
+      workflow_ref: workflow, persona_ref: persona, mode: 'isolated_context',
+      isolation_ref: 'runtime-baseline-v1', goal: 'Prepare a bounded source change safely.',
+      actor_refs: [actor],
+      nodes: [{
+        id: 'node.baseline.inspect', operation_ref: operation,
+        intent: 'Inspect current source and prepare a bounded change.',
+        permission: { decision: 'allowed', actor_ref: actor, rationale: 'The repository maintainer owns this bounded change.' },
+        inputs: [{ id: 'change-request', source: 'actor', required: true, rationale: 'The maintainer supplies the requested change.' }],
+        input_policy: { mode: 'actor_provided', rationale: 'The request is supplied by the maintainer.' },
+        relationship_policy: { mode: 'none', rationale: 'The operation creates no identity relationship.' },
+        surface_refs: [],
+        state_coverage: [
+          { kind: 'entry', applicable: true, visible_state: 'The current source is available for inspection.' },
+          { kind: 'in_progress', applicable: true, visible_state: 'Preparation progress is visible.' },
+          { kind: 'empty', applicable: false, rationale: 'The pinned repository is non-empty.' },
+          { kind: 'success', applicable: true, visible_state: 'A bounded preparation packet is available.' },
+          { kind: 'failure', applicable: true, visible_state: 'The preparation failure is visible.' },
+          { kind: 'denied', applicable: false, rationale: 'The seeded maintainer is authorized.' },
+          { kind: 'recovery', applicable: true, visible_state: 'The request can be corrected and retried.' },
+        ],
+        scenario_coverage: [{ scenario_ref: scenario, applicable: true, trigger: 'Preparation cannot preserve the invariant.', expected: 'Preparation fails closed.', recovery: 'Refine the bounded request and retry.', preserves_input: true }],
+        edge_case_coverage: [
+          ['validation', true], ['authorization', true], ['duplicate', false], ['self_reference', false],
+          ['concurrency', true], ['stale_data', true], ['interruption', true], ['retry', true], ['connectivity', true],
+        ].map(([kind, applicable]) => applicable ? {
+          kind, applicable, trigger: `${kind} affects preparation.`, expected: 'No unsafe source edit is authorized.', recovery: 'Refresh the source or request and retry.',
+        } : { kind, applicable, rationale: 'This bounded preparation creates no relationship or duplicate effect.' }),
+        invariant_probes: [{ invariant_ref: invariant, applicable: true, attempt: 'Prepare a change that would overwrite unrelated behavior.', expected: 'Preparation fails closed.' }],
+        transitions: [
+          { outcome: 'success', terminal: true, expected: 'A useful packet is returned.' },
+          { outcome: `scenario:${scenario}`, terminal: true, expected: 'The failure and recovery are visible.' },
+        ],
+      }],
+      discoveries: { personas: [], actors: [], operations: [], scenarios: [], invariants: [], surfaces: [], branches: [], open_decisions: [] },
+    },
+  }, repository);
+  const request = path.join(repository, '.git', 'lamina', 'work', 'baseline-request.txt');
+  fs.mkdirSync(path.dirname(request), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(request, 'Prepare one bounded source change while preserving existing behavior.\n', { mode: 0o600 });
+  return { workflow, request };
+}
+
+function timeSync(callback) {
+  const started = process.hrtime.bigint();
+  const value = callback();
+  return { wall_time_ns: Number(process.hrtime.bigint() - started), value };
+}
+
+async function disposeRepository(repository) {
+  const paths = runtimePaths(repository);
+  await stopIncompatibleServer(paths).catch(() => {});
+  fs.rmSync(repository, { recursive: true, force: false });
+  return {
+    repository_removed: !fs.existsSync(repository),
+    socket_removed: !fs.existsSync(paths.socket),
+    lock_removed: !fs.existsSync(paths.lock),
+  };
+}
+
+function compactDiagnostics(value) {
+  return {
+    backend: value?.backend || null,
+    mode: value?.mode || null,
+    generation: value?.generation || value?.status?.generation || null,
+    expected: value?.expected ?? value?.counts?.expected ?? null,
+    observed: value?.observed?.count ?? value?.counts?.committed ?? null,
+    source_key_count: value?.observed?.source_key_count ?? null,
+    counts: value?.counts || value?.status?.counts || null,
+    freshness: value?.freshness || value?.status?.freshness || null,
+    index_digest: value?.index_digest || value?.status?.index_digest || null,
+    packet_id: value?.packet_id || null,
+    obligation_count: Array.isArray(value?.obligations) ? value.obligations.length : null,
+    experience_case_count: Array.isArray(value?.experience_cases) ? value.experience_cases.length : null,
+  };
+}
+
+function changeFiles(repository, count) {
+  const candidates = git(repository, ['ls-files', '-z']).stdout.split('\0').filter(Boolean)
+    .filter((relative) => /\.(?:js|jsx|mjs|ts|tsx|py)$/.test(relative))
+    .filter((relative) => !relative.includes('node_modules/'))
+    .sort((left, right) => fs.statSync(path.join(repository, left)).size - fs.statSync(path.join(repository, right)).size)
+    .slice(0, count);
+  if (candidates.length !== count) fail('fixture lacks enough mutable source files');
+  for (const relative of candidates) fs.appendFileSync(path.join(repository, relative), '\n// lamina runtime baseline bounded change\n');
+  git(repository, ['add', '--', ...candidates]);
+  git(repository, ['-c', 'user.name=Lamina Baseline', '-c', 'user.email=baseline@lamina.invalid', 'commit', '-m', `baseline ${count}-file change`]);
+  return candidates;
+}
+
+async function runSample({ fixture, manifest, source, scenario, index }) {
+  const repository = freshRepository(source, fixture, scenario, index);
+  const metadata = repositoryMetadata(repository, manifest, fixture);
+  let seeded = null;
+  let measurement;
+  let diagnostics = {};
+  try {
+    if (!['doctor-status-startup'].includes(scenario)) seeded = await seedGraph(repository);
+    if (scenario === 'doctor-status-startup') {
+      measurement = timeSync(() => ({
+        doctor: cli(repository, ['doctor', '--json']),
+        status: cli(repository, ['graph', 'status']),
+      }));
+      diagnostics = { graph_version: measurement.value.status.graph_version || null };
+    } else if (scenario === 'initial-observation') {
+      measurement = timeSync(() => cli(repository, ['graph', 'observe']));
+      diagnostics = compactDiagnostics(measurement.value);
+      if (diagnostics.source_key_count !== metadata.indexed_candidate_files) {
+        fail('observation indexed count contradicts the pinned candidate set', { diagnostics, metadata });
+      }
+    } else if (scenario === 'initial-retrieval-readiness') {
+      measurement = timeSync(() => cli(repository, ['context', 'rebuild']));
+      diagnostics = compactDiagnostics(measurement.value);
+    } else if (scenario === 'first-useful-preparation') {
+      const output = path.join(repository, '.git', 'lamina', 'work', 'packet.json');
+      measurement = timeSync(() => cli(repository, ['work', 'prepare', '--request-file', seeded.request, '--workflow', seeded.workflow, '--output', output]));
+      diagnostics = compactDiagnostics(measurement.value);
+    } else if (scenario === 'one-file-change' || scenario === 'multi-file-change') {
+      const changed = changeFiles(repository, scenario === 'one-file-change' ? 1 : 5);
+      measurement = timeSync(() => cli(repository, ['graph', 'observe']));
+      diagnostics = { ...compactDiagnostics(measurement.value), changed_files: changed };
+    } else if (scenario === 'full-derived-state-rebuild') {
+      cli(repository, ['graph', 'observe']);
+      cli(repository, ['context', 'rebuild']);
+      measurement = timeSync(() => ({
+        observation: cli(repository, ['graph', 'rebuild-observations']),
+        retrieval: cli(repository, ['context', 'rebuild']),
+      }));
+      diagnostics = {
+        observation: compactDiagnostics(measurement.value.observation),
+        retrieval: compactDiagnostics(measurement.value.retrieval),
+      };
+    } else if (scenario === 'post-command-idle-rss') {
+      const status = cli(repository, ['graph', 'status']);
+      const pid = status.pid || runtimePaths(repository).daemon?.pid;
+      const readRss = () => {
+        try {
+          const line = fs.readFileSync(`/proc/${pid}/status`, 'utf8').split('\n').find((item) => item.startsWith('VmRSS:'));
+          return Number(line?.match(/\d+/)?.[0] || 0) * 1024;
+        } catch { return 0; }
+      };
+      const before = readRss();
+      measurement = timeSync(() => run('/bin/sh', ['-c', 'read _ || exit 0'], { input: '', timeout: 5_000 }));
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      diagnostics = { graphd_pid: pid || null, idle_rss_before_bytes: before, idle_rss_after_bytes: readRss(), idle_window_ms: 2000 };
+    } else {
+      fail('scenario is not a cold sample', { scenario });
+    }
+    return {
+      index,
+      wall_time_ns: measurement.wall_time_ns,
+      repository: metadata,
+      diagnostics,
+      cleanup: await disposeRepository(repository),
+    };
+  } catch (error) {
+    await disposeRepository(repository).catch(() => {});
+    throw error;
+  }
+}
+
+async function warmScenario({ fixture, manifest, source, scenario }) {
+  const repository = freshRepository(source, fixture, scenario, 0);
+  const metadata = repositoryMetadata(repository, manifest, fixture);
+  const seeded = await seedGraph(repository);
+  const samples = [];
+  const diagnostics = [];
+  const total = scenario === 'warm-preparation' ? WARMUP_SAMPLES + WARM_SAMPLES : COLD_RUNS;
+  try {
+    for (let index = 0; index < total; index += 1) {
+      let measured;
+      if (scenario === 'warm-preparation') {
+        const output = path.join(repository, '.git', 'lamina', 'work', `packet-${index}.json`);
+        measured = timeSync(() => cli(repository, ['work', 'prepare', '--request-file', seeded.request, '--workflow', seeded.workflow, '--output', output]));
+      } else {
+        measured = timeSync(() => cli(repository, ['graph', 'observe']));
+      }
+      if (scenario !== 'warm-preparation' || index >= WARMUP_SAMPLES) samples.push(measured.wall_time_ns);
+      diagnostics.push(compactDiagnostics(measured.value));
+    }
+    return {
+      samples,
+      statistics: summarizeNanoseconds(samples, scenario === 'warm-preparation'),
+      classification: scenario === 'warm-preparation' ? 'warm' : 'repeated-expensive',
+      warmups_excluded: scenario === 'warm-preparation' ? WARMUP_SAMPLES : 0,
+      p95_omitted_reason: scenario === 'noop-synchronization'
+        ? 'A no-op observation still scans the real repository; 30 repetitions are materially expensive at medium and large scale.' : null,
+      repository: metadata,
+      diagnostics: diagnostics.slice(-3),
+      cleanup: await disposeRepository(repository),
+    };
+  } catch (error) {
+    await disposeRepository(repository).catch(() => {});
+    throw error;
+  }
+}
+
+async function cancellationScenario({ fixture, manifest, source, scenario }) {
+  const repository = freshRepository(source, fixture, scenario, 0);
+  const metadata = repositoryMetadata(repository, manifest, fixture);
+  await seedGraph(repository);
+  const child = spawn(process.execPath, [CLI, 'graph', 'observe', '--live'], {
+    cwd: repository, env: childEnvironment(), detached: true, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout = `${stdout}${chunk}`.slice(-4000); });
+  child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-4000); });
+  await new Promise((resolve) => setTimeout(resolve, 2_000));
+  try { process.kill(-child.pid, 'SIGTERM'); } catch { try { child.kill('SIGTERM'); } catch {} }
+  const [code, signal] = await Promise.race([
+    once(child, 'exit'),
+    new Promise((resolve) => setTimeout(() => resolve([null, 'TIMEOUT']), 10_000)),
+  ]);
+  if (signal === 'TIMEOUT') {
+    try { process.kill(-child.pid, 'SIGKILL'); } catch {}
+    await once(child, 'exit').catch(() => {});
+  }
+  const cleanup = await disposeRepository(repository);
+  return {
+    samples: [],
+    statistics: null,
+    classification: 'expected-cancellation',
+    repository: metadata,
+    diagnostics: { exit_code: code, exit_signal: signal, stdout_tail: stdout, stderr_tail: stderr },
+    cleanup,
+  };
+}
+
+async function execute(fixtureId, scenario, modelFile, workerFile) {
+  ensureOwnedRoot();
+  const { manifest, digest: manifestDigest } = loadManifest();
+  const fixture = fixtureById(fixtureId);
+  assertScenario(scenario);
+  if (process.platform !== 'linux' || process.arch !== 'x64') fail('baseline v1 is pinned to Linux x64');
+  runtimeInputs = {
+    model: assertPinnedInput(modelFile, manifest.runtime_assets.model, 'retrieval model'),
+    worker: assertPinnedInput(workerFile, manifest.runtime_assets.worker_linux_x64, 'CocoIndex worker'),
+  };
+  const runtimeFootprint = prepareRuntimeAssets(manifest);
+  const source = ensureSource(fixture);
+  let payload;
+  if (scenario === 'footprint') {
+    const repository = freshRepository(source, fixture, scenario, 0);
+    const metadata = repositoryMetadata(repository, manifest, fixture);
+    const cleanup = await disposeRepository(repository);
+    payload = { samples: [], statistics: null, classification: 'static', repository: metadata, diagnostics: runtimeFootprint, cleanup };
+  } else if (['warm-preparation', 'noop-synchronization'].includes(scenario)) {
+    payload = await warmScenario({ fixture, manifest, source, scenario });
+  } else if (scenario === 'cancellation-shutdown-cleanup') {
+    payload = await cancellationScenario({ fixture, manifest, source, scenario });
+  } else {
+    const samples = [];
+    for (let index = 0; index < COLD_RUNS; index += 1) {
+      samples.push(await runSample({ fixture, manifest, source, scenario, index }));
+    }
+    const latencies = samples.map((sample) => sample.wall_time_ns);
+    payload = {
+      samples: samples.map(({ repository: _repository, ...sample }) => sample),
+      statistics: summarizeNanoseconds(latencies, false),
+      classification: 'cold',
+      repository: samples[0].repository,
+      diagnostics: samples.map((sample) => sample.diagnostics),
+      cleanup: {
+        repository_removed: samples.every((sample) => sample.cleanup.repository_removed),
+        socket_removed: samples.every((sample) => sample.cleanup.socket_removed),
+        lock_removed: samples.every((sample) => sample.cleanup.lock_removed),
+      },
+    };
+  }
+  const record = {
+    schema: WORKLOAD_SCHEMA,
+    manifest_digest: manifestDigest,
+    fixture: { id: fixture.id, name: fixture.name, url: fixture.url, commit: fixture.commit, class: fixture.class, languages: fixture.languages, polyglot: fixture.polyglot === true },
+    scenario,
+    runtime: { node: process.version, lamina_commit: git(REPOSITORY, ['rev-parse', 'HEAD']).stdout.trim(), assets_release: manifest.runtime_assets.release },
+    ...payload,
+  };
+  const output = JSON.stringify(record);
+  if (Buffer.byteLength(output) > MAX_WORKLOAD_OUTPUT_BYTES) fail('workload record exceeds its bounded output contract');
+  process.stdout.write(`${output}\n`);
+}
+
+const [command, first, second, third, fourth] = process.argv.slice(2);
+try {
+  if (command === 'run') {
+    if (!first || !second || !third || !fourth || process.argv.length !== 7) {
+      fail('run requires exactly <fixture> <scenario> <model-file> <worker-file>');
+    }
+    await execute(first, second, third, fourth);
+  } else if (command === 'cleanup') {
+    if (first || second) fail('cleanup accepts no arguments');
+    process.stdout.write(`${JSON.stringify({ schema: WORKLOAD_SCHEMA, cleanup: cleanupOwnedRoot() })}\n`);
+  } else if (command === 'list') {
+    process.stdout.write(`${JSON.stringify({ fixtures: loadManifest().manifest.fixtures.map((item) => item.id), scenarios: SCENARIOS })}\n`);
+  } else {
+    fail('usage: workload.mjs <run FIXTURE SCENARIO|cleanup|list>');
+  }
+} catch (error) {
+  process.stderr.write(`${stableJson({
+    schema: 'lamina.runtime-baseline-error/v1',
+    error: { message: error.message, details: error.details || {} },
+  })}`);
+  process.exitCode = 1;
+}

--- a/docs/decisions/014-crash-safe-resource-supervision.md
+++ b/docs/decisions/014-crash-safe-resource-supervision.md
@@ -60,7 +60,10 @@ The runner:
 - resolves `systemd-run`, `systemctl`, bwrap, Node, and the shell from persisted,
   launch-rechecked host identities (including absolute SHA-pinned CI bwrap) and
   strips PATH plus loader/Node/exported-function/runtime-hook families before any
-  infrastructure process starts;
+  infrastructure process starts. A distribution bwrap whose sandbox authority is
+  attached to its pathname by a host LSM retains that canonical path only when the
+  executable and every ancestor are immutable, physical, root-owned objects; its
+  digest, inode, mode, link count, and ownership are rechecked before launch;
 - terminates the complete scope on memory, PID, timeout, output, temporary
   disk, controller signal, or detached-descendant failure;
 - identifies processes by PID plus Linux start ticks so stale records cannot
@@ -100,6 +103,12 @@ records exact device/inode/owner/type identities and validates the lock PID.
 Normal and watchdog cleanup share the same `lstat`-based immediate pre-unlink
 identity recheck. Dangling symlinks, unsealed foreign objects, and same-user
 replacements remain in place and keep cleanup incomplete.
+Paths observed through `/proc/<pid>/root` and `/proc/<pid>/cwd` are interpreted
+in the payload mount namespace. Namespace-private managed paths are verified one
+component at a time before use; the supervisor does not `realpath` them back into
+its own namespace. Likewise, cwd attestation reads the kernel-provided proc link,
+requires an absolute non-deleted target, and does not require the private path to
+exist in the supervisor namespace.
 On Windows, graphd emits one canonical `Path` entry: the native-extension
 directory is prepended to the inherited path found case-insensitively, retaining
 Git discovery while all execution-hook environment families remain stripped.
@@ -222,10 +231,25 @@ only the two small scratch fixtures receive that entrypoint-specific binding.
 Object alternates and config includes are never admitted. Inherited `GIT_*`
 controls are removed, while
 system and global Git config reads are deterministically disabled.
-The same authority descriptor-copies Node, bwrap, the gate scripts, and the
-sandbox launcher/import before systemd launch. The shell and systemd launcher
-remain host-trusted infrastructure; bwrap and later stages execute their staged
-objects, so a post-validation pathname swap cannot choose the sandbox binary.
+The same authority descriptor-copies Node, explicitly pinned or user-owned
+bwrap, the gate scripts, and the sandbox launcher/import before systemd launch.
+The shell and systemd launcher remain host-trusted infrastructure. A root-owned
+distribution bwrap is the narrow exception: Ubuntu AppArmor and comparable
+path-based LSM policy may authorize `/usr/bin/bwrap` but reject a byte-identical
+copy at a temporary path. For that case, preserving the canonical executable is
+part of preserving the host security identity rather than an escape from the
+snapshot. The runner requires a physical root-owned file, root-owned physical
+ancestors, no group/world write bit, no setuid/setgid bit, and matching digest,
+device, inode, mode, size, and link count at discovery, snapshot construction,
+snapshot revalidation, and launch. A separately identity-checked root-owned
+`getcap` must also prove that the executable has no file capabilities at each
+check; capability-bearing system helpers refuse. A compromised root account or
+package database remains outside this threat model.
+Pinned and current-user helpers never receive this exception and continue to be
+executed from their descriptor-copied objects. On Node versions that provide
+`process.execve`, the validated sandbox launcher replaces itself with bwrap so
+its idle V8 thread pool does not consume the payload's task budget; older Node
+versions retain the validated spawn-and-signal-forwarding fallback.
 Large ignored runtimes are not silently exposed again after the repository
 mount. In particular, eval-suite `.venv-eval` execution is refused with an
 actionable bounded-runtime requirement. Retrieval qualification has no uv or

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bench:retrieval": "npm run safe:run -- --tier small --workload retrieval-v1 --promote --report .lamina-safe-runner/retrieval-evaluate-small.json -- node benchmarks/retrieval-v1/benchmark.mjs --evaluate",
     "bench:runtime": "node benchmarks/runtime-v1/harness.mjs",
     "test:runtime-benchmark": "node tests/runtime_benchmark_unit_controller.mjs",
+    "test:runtime-baseline": "node tests/runtime_baseline_test.mjs",
     "test:runtime-benchmark:integration": "node tests/runtime_benchmark_integration_test.mjs",
     "graphd": "node packages/cli/lib/graph-runtime/server.mjs",
     "graph:observe": "node packages/cli/bin/lamina.mjs graph observe",

--- a/packages/cli/lib/graph-runtime/util.mjs
+++ b/packages/cli/lib/graph-runtime/util.mjs
@@ -139,6 +139,16 @@ function graphSocketAlias(paths) {
   return path.join(alias, 'graphd.sock');
 }
 
+function socketDirectoryDescriptor(paths) {
+  fs.mkdirSync(paths.runtime_dir, { recursive: true });
+  let fd = socketDirectoryFds.get(paths.runtime_dir);
+  if (fd === undefined) {
+    fd = fs.openSync(paths.runtime_dir, fs.constants.O_RDONLY);
+    socketDirectoryFds.set(paths.runtime_dir, fd);
+  }
+  return fd;
+}
+
 export function graphSocketPath(paths, platform = process.platform) {
   if (platform === 'win32') {
     const hash = crypto.createHash('sha256')
@@ -148,30 +158,29 @@ export function graphSocketPath(paths, platform = process.platform) {
     return `\\\\.\\pipe\\laminadev-${hash}`;
   }
   if (Buffer.byteLength(paths.socket) < 100) return paths.socket;
-  fs.mkdirSync(paths.runtime_dir, { recursive: true });
   // Linux resolves a Unix socket path through an open directory descriptor
   // before applying the sockaddr length limit. This keeps the socket itself at
   // the canonical clone-local path and, unlike /tmp aliases, remains reachable
   // when a caller has an isolated filesystem view (for example Codex's
   // workspace sandbox).
   if (fs.existsSync('/proc/self/fd')) {
-    let fd = socketDirectoryFds.get(paths.runtime_dir);
-    if (fd === undefined) {
-      fd = fs.openSync(paths.runtime_dir, fs.constants.O_RDONLY);
-      socketDirectoryFds.set(paths.runtime_dir, fd);
-    }
+    const fd = socketDirectoryDescriptor(paths);
     return `/proc/self/fd/${fd}/graphd.sock`;
   }
   return graphSocketAlias(paths);
 }
 
-// `/proc/self/fd` is process-local. It is ideal for graphd and its Node client,
-// but a Python/native observation worker cannot resolve the parent's directory
-// descriptor after exec. Use a short, ownership-checked filesystem alias for
-// endpoints that cross a process boundary.
+// `/proc/self/fd` is process-local, but a child that shares this PID namespace
+// can resolve the still-live parent's directory descriptor explicitly. This
+// crosses exec without creating a temporary symlink or moving the canonical
+// socket away from the repository runtime directory.
 export function graphSocketChildPath(paths, platform = process.platform) {
   if (platform === 'win32' || Buffer.byteLength(paths.socket) < 100) {
     return graphSocketPath(paths, platform);
+  }
+  if (fs.existsSync('/proc/self/fd')) {
+    const fd = socketDirectoryDescriptor(paths);
+    return `/proc/${process.pid}/fd/${fd}/graphd.sock`;
   }
   return graphSocketAlias(paths);
 }

--- a/packages/cli/lib/graph-runtime/util.mjs
+++ b/packages/cli/lib/graph-runtime/util.mjs
@@ -123,6 +123,11 @@ function normalizedRepositoryPath(value, platform = process.platform) {
 function graphSocketAlias(paths) {
   const uid = typeof process.getuid === 'function' ? process.getuid() : 0;
   const aliases = path.join(os.tmpdir(), `lamina-graphd-${uid}`);
+  // existsSync follows symlinks, so an alias to a not-yet-created runtime
+  // directory looks absent and a second caller would attempt to recreate the
+  // still-present symlink. Materialize the canonical target before probing the
+  // fallback alias. The /proc descriptor path does this in its own helper.
+  fs.mkdirSync(paths.runtime_dir, { recursive: true });
   fs.mkdirSync(aliases, { recursive: true, mode: 0o700 });
   const stat = fs.lstatSync(aliases);
   if (!stat.isDirectory() || stat.isSymbolicLink() ||
@@ -163,7 +168,7 @@ export function graphSocketPath(paths, platform = process.platform) {
   // the canonical clone-local path and, unlike /tmp aliases, remains reachable
   // when a caller has an isolated filesystem view (for example Codex's
   // workspace sandbox).
-  if (fs.existsSync('/proc/self/fd')) {
+  if (platform === 'linux' && fs.existsSync('/proc/self/fd')) {
     const fd = socketDirectoryDescriptor(paths);
     return `/proc/self/fd/${fd}/graphd.sock`;
   }
@@ -178,7 +183,7 @@ export function graphSocketChildPath(paths, platform = process.platform) {
   if (platform === 'win32' || Buffer.byteLength(paths.socket) < 100) {
     return graphSocketPath(paths, platform);
   }
-  if (fs.existsSync('/proc/self/fd')) {
+  if (platform === 'linux' && fs.existsSync('/proc/self/fd')) {
     const fd = socketDirectoryDescriptor(paths);
     return `/proc/${process.pid}/fd/${fd}/graphd.sock`;
   }

--- a/scripts/safe-runner/broker.mjs
+++ b/scripts/safe-runner/broker.mjs
@@ -27,7 +27,7 @@ export function exactGraphdLaunchAuthorized(child, reservation, launchAuthority 
       const canonicalLock = reservation.canonical_lock || reservation.lock;
       return child.argv.length === expected.argv.length
         && child.argv.every((value, index) => value === expected.argv[index])
-        && child.cwd === expected.argv[2]
+        && typeof expected.cwd === 'string' && child.cwd === expected.cwd
         && canonicalSocket === path.join(expected.runtime_directory, 'graphd.sock')
         && canonicalLock === path.join(expected.runtime_directory, 'graphd.lock');
     }

--- a/scripts/safe-runner/broker.mjs
+++ b/scripts/safe-runner/broker.mjs
@@ -23,10 +23,13 @@ export function exactGraphdLaunchAuthorized(child, reservation, launchAuthority 
       child.executable_identity?.[field] === expected.executable_identity?.[field]);
     if (!executableMatches) return false;
     if (expected.kind === 'exact') {
+      const canonicalSocket = reservation.canonical_socket || reservation.socket;
+      const canonicalLock = reservation.canonical_lock || reservation.lock;
       return child.argv.length === expected.argv.length
         && child.argv.every((value, index) => value === expected.argv[index])
-        && reservation.socket === path.join(expected.runtime_directory, 'graphd.sock')
-        && reservation.lock === path.join(expected.runtime_directory, 'graphd.lock');
+        && child.cwd === expected.argv[2]
+        && canonicalSocket === path.join(expected.runtime_directory, 'graphd.sock')
+        && canonicalLock === path.join(expected.runtime_directory, 'graphd.lock');
     }
     if (expected.kind === 'standalone-cwd') {
       const runtimeDirectory = path.join(child.cwd || '', '.git', 'lamina');
@@ -77,10 +80,28 @@ export function authorizeBrokerRequest(request, authority) {
       || path.basename(request.lock) !== 'graphd.lock') {
       return { ok: false, error: 'managed graphd reservation requires canonical absolute socket/lock siblings' };
     }
+    const canonicalSocket = path.resolve(request.socket);
+    const canonicalLock = path.resolve(request.lock);
+    const resolved = authority.resolveManagedGraphdPaths
+      ? authority.resolveManagedGraphdPaths({
+        requester, socket: canonicalSocket, lock: canonicalLock,
+      })
+      : { socket: canonicalSocket, lock: canonicalLock };
+    if (!resolved) {
+      return { ok: false, error: 'managed graphd paths are outside sealed execution authority' };
+    }
+    if (typeof resolved.socket !== 'string' || !path.isAbsolute(resolved.socket)
+      || typeof resolved.lock !== 'string' || !path.isAbsolute(resolved.lock)
+      || path.dirname(resolved.socket) !== path.dirname(resolved.lock)
+      || path.basename(resolved.socket) !== 'graphd.sock'
+      || path.basename(resolved.lock) !== 'graphd.lock') {
+      return { ok: false, error: 'managed graphd paths are outside sealed execution authority' };
+    }
     const reservation = authority.reserve({
       token: crypto.randomBytes(32).toString('hex'),
       requester: { pid: requester.pid, start_ticks: requester.start_ticks },
-      socket: path.resolve(request.socket), lock: path.resolve(request.lock),
+      socket: path.resolve(resolved.socket), lock: path.resolve(resolved.lock),
+      canonical_socket: canonicalSocket, canonical_lock: canonicalLock,
     });
     return reservation ? { ok: true, reservation: reservation.token }
       : { ok: false, error: 'managed graphd paths were not proven absent and durably reserved' };
@@ -113,8 +134,8 @@ export function authorizeBrokerRequest(request, authority) {
         namespace_pid: Number(request.child.pid),
         start_ticks: child.start_ticks,
         role: 'graphd',
-        socket: reservation.socket,
-        lock: reservation.lock,
+        socket: reservation.canonical_socket || reservation.socket,
+        lock: reservation.canonical_lock || reservation.lock,
       },
     };
   }

--- a/scripts/safe-runner/execution-snapshot.mjs
+++ b/scripts/safe-runner/execution-snapshot.mjs
@@ -63,6 +63,9 @@ const EXPLICIT_ENTRYPOINT_DEPENDENCIES = new Map([
     {
       name: '@ladybugdb/core', resolver: 'packages/cli/package.json',
       destination: 'packages/cli/node_modules',
+      // @ladybugdb/core@0.19.0 loads only its relative JS modules and native
+      // addon at runtime. Its declared dependencies are build/install tooling.
+      omit_dependency_edges: true,
     },
   ]],
 ]);
@@ -680,7 +683,11 @@ export function prepareExecutionSnapshot({
   const environmentOverrides = {};
   let totalBytes = 0;
   let dependencyCreatedDirectories = 0;
-  const sourceFiles = repositoryFiles(repository);
+  const sourceFiles = repositoryFiles(repository).filter((relative) =>
+    auditedEntrypoint !== RUNTIME_BASELINE_ENTRYPOINT
+      || relative === RUNTIME_BASELINE_ENTRYPOINT
+      || relative.startsWith('benchmarks/runtime-baseline-v1/')
+      || relative.startsWith('packages/cli/'));
   for (const relative of sourceFiles) {
     const source = path.join(repository, relative);
     const destination = path.join(snapshotRepository, relative);
@@ -956,10 +963,10 @@ export function prepareExecutionSnapshot({
   if (head) {
     // The runtime baseline uses the Lamina checkout only as immutable executable
     // source and reads its HEAD identifier; all repository lifecycle work occurs
-    // in separately cloned pinned fixtures. Seal the current commit/tree without
-    // copying unrelated Lamina history beside the large pinned runtime inputs.
+    // in separately cloned pinned fixtures. Seal that identifier without copying
+    // unrelated Lamina history beside the large pinned runtime inputs.
     const reachable = auditedEntrypoint === RUNTIME_BASELINE_ENTRYPOINT
-      ? `${head}\n${gitOutput(repository, ['rev-list', '--objects', 'HEAD^{tree}'])}`
+      ? head
       : gitOutput(repository, ['rev-list', '--objects', 'HEAD']);
     for (const item of reachable.split('\n').filter(Boolean)) {
       const oid = item.match(/^([a-f0-9]{40,64})(?:\s|$)/)?.[1];
@@ -967,11 +974,13 @@ export function prepareExecutionSnapshot({
       objectIds.add(oid);
     }
   }
-  const staged = gitOutput(repository, ['ls-files', '--stage', '-z']);
-  for (const item of staged.split('\0').filter(Boolean)) {
-    const oid = item.match(/^[0-7]{6}\s+([a-f0-9]{40,64})\s+[0-3]\t/)?.[1];
-    if (!oid) throw new Error('cannot parse Git index object closure');
-    objectIds.add(oid);
+  if (auditedEntrypoint !== RUNTIME_BASELINE_ENTRYPOINT) {
+    const staged = gitOutput(repository, ['ls-files', '--stage', '-z']);
+    for (const item of staged.split('\0').filter(Boolean)) {
+      const oid = item.match(/^[0-7]{6}\s+([a-f0-9]{40,64})\s+[0-3]\t/)?.[1];
+      if (!oid) throw new Error('cannot parse Git index object closure');
+      objectIds.add(oid);
+    }
   }
   if (objectIds.size > 0) {
     const objectInput = `${[...objectIds].join('\n')}\n`;
@@ -1123,7 +1132,8 @@ export function prepareExecutionSnapshot({
     const stagePackage = (dependency, policy = {}) => {
       const physicalRoot = fs.realpathSync.native(dependency.root);
       const existing = sealedPackages.get(physicalRoot);
-      const policyKey = policy.omit_direct_optional_dependencies === true ? 'omit-optional' : 'full';
+      const policyKey = policy.omit_dependency_edges === true ? 'leaf'
+        : policy.omit_direct_optional_dependencies === true ? 'omit-optional' : 'full';
       if (existing) {
         if (sealedPackagePolicies.get(physicalRoot) !== policyKey) {
           throw new Error('execution dependency root was selected with incompatible policies');
@@ -1142,9 +1152,10 @@ export function prepareExecutionSnapshot({
       visit(physicalRoot, sealedRoot, `node_modules/.lamina-sealed/${id}`, physicalRoot,
         sealedRoot);
 
-      for (const edge of packageEdges(dependency.manifest, {
+      const edges = policy.omit_dependency_edges === true ? [] : packageEdges(dependency.manifest, {
         omitOptionalDependencies: policy.omit_direct_optional_dependencies === true,
-      }).values()) {
+      }).values();
+      for (const edge of edges) {
         const child = resolveInstalledPackage(
           repository, dependency.manifest_path, edge.logical_name, edge.optional,
           edge.manifest_name,

--- a/scripts/safe-runner/execution-snapshot.mjs
+++ b/scripts/safe-runner/execution-snapshot.mjs
@@ -22,6 +22,14 @@ const MAX_CLOSURE_PACKAGES = 4_096;
 const MAX_CLOSURE_INODES = 2_000_000;
 const MAX_CLOSURE_BYTES = 16 * 1024 ** 3;
 const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RUNTIME_BASELINE_ENTRYPOINT = 'benchmarks/runtime-baseline-v1/workload.mjs';
+const RUNTIME_BASELINE_SCENARIOS = new Set([
+  'footprint', 'doctor-status-startup', 'initial-observation',
+  'initial-retrieval-readiness', 'first-useful-preparation', 'warm-preparation',
+  'noop-synchronization', 'one-file-change', 'multi-file-change',
+  'full-derived-state-rebuild', 'post-command-idle-rss',
+  'cancellation-shutdown-cleanup',
+]);
 
 export function assertGitObjectClosureBudget(objectCount, uncompressedBytes, currentBytes = 0) {
   if (!Number.isSafeInteger(objectCount) || objectCount < 0 || objectCount > MAX_GIT_OBJECTS
@@ -46,6 +54,12 @@ const EXPLICIT_ENTRYPOINT_DEPENDENCIES = new Map([
     { name: 'postject', resolver: 'package.json', destination: 'node_modules' },
   ]],
   ['scripts/prepare-retrieval-assets.mjs', [
+    {
+      name: '@ladybugdb/core', resolver: 'packages/cli/package.json',
+      destination: 'packages/cli/node_modules',
+    },
+  ]],
+  [RUNTIME_BASELINE_ENTRYPOINT, [
     {
       name: '@ladybugdb/core', resolver: 'packages/cli/package.json',
       destination: 'packages/cli/node_modules',
@@ -248,6 +262,7 @@ function entrypointRelative(repository, command, cwd = repository) {
     if (!relative.startsWith('../') && (repositoryOutputRefusal(relative)
       || EXPLICIT_ENTRYPOINT_ARGV_OUTPUTS.has(relative)
       || EXPLICIT_ENTRYPOINT_ENV_FILE_INPUTS.has(relative)
+      || relative === RUNTIME_BASELINE_ENTRYPOINT
       || relative === RETRIEVAL_BENCHMARK_ENTRYPOINT)) return relative;
   }
   return null;
@@ -719,6 +734,81 @@ export function prepareExecutionSnapshot({
       throw new Error('execution argv snapshot exceeds its bounded budget');
     }
   }
+  let runtimeBaseline = null;
+  if (auditedEntrypoint === RUNTIME_BASELINE_ENTRYPOINT) {
+    if (command.length !== 7 || command[2] !== 'run'
+      || !['small', 'medium', 'large'].includes(command[3])
+      || !RUNTIME_BASELINE_SCENARIOS.has(command[4])) {
+      throw new Error('runtime baseline execution command changed after preflight');
+    }
+    const manifestFile = path.join(repository, 'benchmarks/runtime-baseline-v1/manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+    const fixture = manifest?.fixtures?.find((item) => item?.id === command[3]);
+    const expectedInputs = [
+      { index: 5, label: 'model', expected: manifest?.runtime_assets?.model, executable: false },
+      {
+        index: 6, label: 'worker', expected: manifest?.runtime_assets?.worker_linux_x64,
+        executable: true,
+      },
+    ];
+    if (manifest?.schema !== 'lamina.runtime-baseline-manifest/v1'
+      || manifest?.version !== 1 || !fixture) {
+      throw new Error('runtime baseline manifest changed after preflight');
+    }
+    const sealedInputs = {};
+    for (const input of expectedInputs) {
+      const source = path.resolve(cwd, command[input.index]);
+      const relative = path.relative(repository, source).replaceAll('\\', '/');
+      if (!relative || relative.startsWith('../') || path.isAbsolute(relative)
+        || !Number.isSafeInteger(input.expected?.bytes)
+        || !/^[a-f0-9]{64}$/.test(input.expected?.sha256 || '')) {
+        throw new Error(`runtime baseline ${input.label} authority is invalid`);
+      }
+      const copied = entries.find((entry) => entry.path === path.join(snapshotRepository, relative));
+      const sourceStat = fs.lstatSync(source, { bigint: true });
+      if (!copied || copied.type !== 'file' || copied.size !== input.expected.bytes
+        || copied.digest !== input.expected.sha256
+        || copied.source_dev !== String(sourceStat.dev)
+        || copied.source_ino !== String(sourceStat.ino)
+        || copied.source_uid !== Number(sourceStat.uid)
+        || copied.source_nlink !== Number(sourceStat.nlink)
+        || copied.source_mode !== Number(sourceStat.mode & 0o777n)
+        || (input.executable && (sourceStat.mode & 0o111n) === 0n)) {
+        throw new Error(`runtime baseline ${input.label} does not match its sealed manifest authority`);
+      }
+      sealedInputs[input.label] = {
+        source, relative, snapshot: copied.path, digest: copied.digest, size: copied.size,
+      };
+    }
+    const workerOverlay = path.join(
+      snapshotRepository, 'packages/cli/observation-runtime/cocoindex-worker',
+    );
+    if (workerOverlay !== sealedInputs.worker.snapshot) {
+      const existing = entries.find((entry) => entry.path === workerOverlay);
+      if (existing) {
+        if (existing.type !== 'file' || existing.digest !== sealedInputs.worker.digest
+          || existing.size !== sealedInputs.worker.size) {
+          throw new Error('runtime baseline worker overlay collides with different sealed bytes');
+        }
+        fs.chmodSync(workerOverlay, 0o500);
+      } else {
+        const copied = copyPhysicalFile(sealedInputs.worker.snapshot, workerOverlay, true);
+        totalBytes += copied.size;
+        entries.push({
+          label: 'runtime-baseline:worker-overlay', path: workerOverlay, type: 'file', ...copied,
+        });
+        copiedDestinations.add(workerOverlay);
+      }
+    }
+    runtimeBaseline = {
+      fixture: command[3], scenario: command[4], inputs: sealedInputs,
+      worker_overlay: path.join(repository, 'packages/cli/observation-runtime/cocoindex-worker'),
+      private_root: path.join(temporaryDirectory, 'payload-tmp', 'runtime-baseline-v1'),
+    };
+    if (entries.length > MAX_FILES || totalBytes > MAX_BYTES) {
+      throw new Error('runtime baseline sealed inputs exceed the execution snapshot budget');
+    }
+  }
   _testBeforeRetrievalCopyValidation?.(retrievalAuthority);
   for (const input of expectedRetrievalAuthority
     ? [retrievalAuthority.worker, retrievalAuthority.model, retrievalAuthority.tokenizer] : []) {
@@ -1134,6 +1224,7 @@ export function prepareExecutionSnapshot({
     : [executable, ...command.slice(1)];
   const graphdLaunchAuthority = [];
   const gitExecutableIdentity = auditedEntrypoint === 'tests/fixtures/safe-runner-graphd-client.mjs'
+    || auditedEntrypoint === RUNTIME_BASELINE_ENTRYPOINT
     ? trustedGitIdentity() : null;
   if (stagedInfrastructure.node
     && auditedEntrypoint === 'tests/fixtures/safe-runner-graphd-client.mjs') {
@@ -1148,6 +1239,25 @@ export function prepareExecutionSnapshot({
       runtime_directory: path.join(fs.realpathSync.native(fixtureCommon), 'lamina'),
       executable_identity: stagedInfrastructure.identities.node,
     });
+  }
+  if (stagedInfrastructure.node && runtimeBaseline) {
+    for (let index = 0; index < 3; index += 1) {
+      const nestedRepository = path.join(
+        runtimeBaseline.private_root, 'runs', runtimeBaseline.fixture,
+        runtimeBaseline.scenario, `sample-${index}`,
+      );
+      graphdLaunchAuthority.push({
+        kind: 'exact',
+        argv: [
+          stagedInfrastructure.node,
+          path.join(repository, 'packages/cli/lib/graph-runtime/server.mjs'),
+          nestedRepository,
+        ],
+        runtime_directory: path.join(nestedRepository, '.git', 'lamina'),
+        private_tmp_root: runtimeBaseline.private_root,
+        executable_identity: stagedInfrastructure.identities.node,
+      });
+    }
   }
   if (auditedEntrypoint === 'tests/cli_binary_smoke_test.mjs'
     && environmentOverrides.LAMINA_BINARY) {
@@ -1223,6 +1333,7 @@ export function prepareExecutionSnapshot({
     git_executable_identity: gitExecutableIdentity,
     environment_overrides: environmentOverrides,
     graphd_launch_authority: graphdLaunchAuthority,
+    runtime_baseline: runtimeBaseline,
     infrastructure: stagedInfrastructure,
     file_count: entries.length, total_bytes: totalBytes,
     digest: crypto.createHash('sha256').update(JSON.stringify(entries.map(({ path: _path, ...entry }) => entry))).digest('hex'),

--- a/scripts/safe-runner/execution-snapshot.mjs
+++ b/scripts/safe-runner/execution-snapshot.mjs
@@ -1253,6 +1253,7 @@ export function prepareExecutionSnapshot({
       argv: [stagedInfrastructure.node,
         path.join(repository, 'tests/fixtures/graph-runtime/server.mjs'),
         fixtureRepository, command[3] || 'clean'],
+      cwd: repository,
       runtime_directory: path.join(fs.realpathSync.native(fixtureCommon), 'lamina'),
       executable_identity: stagedInfrastructure.identities.node,
     });
@@ -1270,6 +1271,7 @@ export function prepareExecutionSnapshot({
           path.join(repository, 'packages/cli/lib/graph-runtime/server.mjs'),
           nestedRepository,
         ],
+        cwd: nestedRepository,
         runtime_directory: path.join(nestedRepository, '.git', 'lamina'),
         private_tmp_root: runtimeBaseline.private_root,
         executable_identity: stagedInfrastructure.identities.node,

--- a/scripts/safe-runner/execution-snapshot.mjs
+++ b/scripts/safe-runner/execution-snapshot.mjs
@@ -954,7 +954,13 @@ export function prepareExecutionSnapshot({
   }
   const objectIds = new Set();
   if (head) {
-    const reachable = gitOutput(repository, ['rev-list', '--objects', 'HEAD']);
+    // The runtime baseline uses the Lamina checkout only as immutable executable
+    // source and reads its HEAD identifier; all repository lifecycle work occurs
+    // in separately cloned pinned fixtures. Seal the current commit/tree without
+    // copying unrelated Lamina history beside the large pinned runtime inputs.
+    const reachable = auditedEntrypoint === RUNTIME_BASELINE_ENTRYPOINT
+      ? `${head}\n${gitOutput(repository, ['rev-list', '--objects', 'HEAD^{tree}'])}`
+      : gitOutput(repository, ['rev-list', '--objects', 'HEAD']);
     for (const item of reachable.split('\n').filter(Boolean)) {
       const oid = item.match(/^([a-f0-9]{40,64})(?:\s|$)/)?.[1];
       if (!oid) throw new Error('cannot parse reachable Git object closure');

--- a/scripts/safe-runner/execution-snapshot.mjs
+++ b/scripts/safe-runner/execution-snapshot.mjs
@@ -5,6 +5,9 @@ import { builtinModules } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { DEFAULTS } from './constants.mjs';
 import { inertRepositoryConfig, spawnTrustedGit, trustedGitIdentity } from './git.mjs';
+import {
+  assertTrustedBinaryIdentity, trustedRootBinaryIdentity,
+} from './infrastructure.mjs';
 import { auditedNpxCommand } from './npx-authority.mjs';
 import { repositoryOutputRefusal } from './output-policy.mjs';
 import {
@@ -30,6 +33,14 @@ const RUNTIME_BASELINE_SCENARIOS = new Set([
   'full-derived-state-rebuild', 'post-command-idle-rss',
   'cancellation-shutdown-cleanup',
 ]);
+
+export function requiresSystemBwrapPath(infrastructure) {
+  const identity = infrastructure?.identities?.bwrap;
+  return infrastructure?.pinned_bwrap === false
+    && identity?.uid === 0
+    && identity?.root_owned_path === true
+    && identity?.path === infrastructure?.bwrap;
+}
 
 export function assertGitObjectClosureBudget(objectCount, uncompressedBytes, currentBytes = 0) {
   if (!Number.isSafeInteger(objectCount) || objectCount < 0 || objectCount > MAX_GIT_OBJECTS
@@ -1178,10 +1189,7 @@ export function prepareExecutionSnapshot({
   }
   const stagedInfrastructure = { identities: {} };
   if (infrastructure) {
-    const binarySources = {
-      node: infrastructure.node,
-      bwrap: infrastructure.bwrap,
-    };
+    const binarySources = { node: infrastructure.node };
     for (const [role, source] of Object.entries(binarySources)) {
       const destination = path.join(root, 'infrastructure', role);
       const copied = copyPhysicalFile(fs.realpathSync.native(source), destination, true);
@@ -1191,7 +1199,42 @@ export function prepareExecutionSnapshot({
       stagedInfrastructure[role] = destination;
       stagedInfrastructure.identities[role] = {
         path: destination, dev: String(stat.dev), ino: String(stat.ino), uid: Number(stat.uid),
-        mode: Number(stat.mode & 0o777n), size: String(stat.size), digest: copied.digest,
+        mode: Number(stat.mode & 0o7777n), size: String(stat.size), digest: copied.digest,
+      };
+    }
+    if (requiresSystemBwrapPath(infrastructure)) {
+      // AppArmor and other path-based LSMs attach their bwrap exception to the
+      // distribution executable (for example /usr/bin/bwrap on Ubuntu). A copy
+      // has identical bytes but a different security identity and can lose the
+      // capabilities needed to finish constructing the network namespace.
+      // Keep only an immutable root-owned system path; user-owned and explicitly
+      // pinned helpers continue through the descriptor-copy authority below.
+      assertTrustedBinaryIdentity(infrastructure.identities.bwrap);
+      const identity = trustedRootBinaryIdentity(infrastructure.bwrap, {
+        expectedDigest: infrastructure.identities.bwrap.digest,
+      });
+      const size = Number(identity.size);
+      totalBytes += size;
+      entries.push({
+        label: 'infrastructure:bwrap-system-path', path: identity.path, type: 'host-file',
+        size, digest: identity.digest,
+        source_dev: identity.dev, source_ino: identity.ino, source_uid: identity.uid,
+        source_mode: identity.mode, source_nlink: identity.nlink,
+        source_file_capabilities: identity.file_capabilities,
+      });
+      stagedInfrastructure.bwrap = identity.path;
+      stagedInfrastructure.identities.bwrap = identity;
+    } else {
+      const source = infrastructure.bwrap;
+      const destination = path.join(root, 'infrastructure', 'bwrap');
+      const copied = copyPhysicalFile(fs.realpathSync.native(source), destination, true);
+      const stat = fs.lstatSync(destination, { bigint: true });
+      totalBytes += copied.size;
+      entries.push({ label: 'infrastructure:bwrap', path: destination, type: 'file', ...copied });
+      stagedInfrastructure.bwrap = destination;
+      stagedInfrastructure.identities.bwrap = {
+        path: destination, dev: String(stat.dev), ino: String(stat.ino), uid: Number(stat.uid),
+        mode: Number(stat.mode & 0o7777n), size: String(stat.size), digest: copied.digest,
       };
     }
     for (const name of ['gate.sh', 'quota-gate.sh', 'sandbox.mjs', 'infrastructure.mjs']) {
@@ -1363,6 +1406,22 @@ export function assertExecutionSnapshot(snapshot) {
   for (const entry of snapshot?.entries || []) {
     if (entry.type === 'symlink') {
       if (fs.readlinkSync(entry.path) !== entry.target) throw new Error('execution snapshot symlink changed');
+      continue;
+    }
+    if (entry.type === 'host-file') {
+      const expected = snapshot?.infrastructure?.identities?.bwrap;
+      const actual = trustedRootBinaryIdentity(entry.path, { expectedDigest: entry.digest });
+      if (entry.label !== 'infrastructure:bwrap-system-path'
+        || expected?.path !== entry.path || expected?.root_owned_path !== true
+        || entry.source_dev !== actual.dev || entry.source_ino !== actual.ino
+        || entry.source_uid !== actual.uid || entry.source_mode !== actual.mode
+        || entry.source_nlink !== actual.nlink || entry.size !== Number(actual.size)
+        || entry.source_file_capabilities !== actual.file_capabilities
+        || entry.digest !== actual.digest
+        || ['path', 'dev', 'ino', 'uid', 'mode', 'nlink', 'size', 'digest', 'file_capabilities']
+          .some((field) => expected?.[field] !== actual[field])) {
+        throw new Error('execution snapshot host infrastructure identity changed');
+      }
       continue;
     }
     const stat = fs.lstatSync(entry.path);

--- a/scripts/safe-runner/filesystem.mjs
+++ b/scripts/safe-runner/filesystem.mjs
@@ -9,6 +9,7 @@ export function boundedDirectorySize(
   let bytes = 0;
   let entries = 0;
   let symlinks = 0;
+  const symlinkPaths = [];
   const stack = [root];
   while (stack.length) {
     const current = stack.pop();
@@ -18,18 +19,27 @@ export function boundedDirectorySize(
       entries += 1;
       const absolute = path.join(current, child.name);
       if (child.isDirectory()) stack.push(absolute);
-      else if (child.isSymbolicLink()) symlinks += 1;
+      else if (child.isSymbolicLink()) {
+        symlinks += 1;
+        const relative = path.relative(root, absolute).replaceAll('\\', '/');
+        if (symlinkPaths.length < 16 && relative.length <= 256
+          && !/[\u0000-\u001f\u007f]/.test(relative)) symlinkPaths.push(relative);
+      }
       else {
         try { bytes += fs.lstatSync(absolute).size; } catch {}
       }
       if (bytes > stopAfterBytes || entries > stopAfterEntries) {
         return {
-          bytes, entries, symlinks, exceeded: true, reason: bytes > stopAfterBytes ? 'bytes' : 'inodes',
+          bytes, entries, symlinks, symlink_paths: symlinkPaths,
+          exceeded: true, reason: bytes > stopAfterBytes ? 'bytes' : 'inodes',
         };
       }
     }
   }
-  return { bytes, entries, symlinks, exceeded: symlinks > 0, reason: symlinks > 0 ? 'symlink' : null };
+  return {
+    bytes, entries, symlinks, symlink_paths: symlinkPaths,
+    exceeded: symlinks > 0, reason: symlinks > 0 ? 'symlink' : null,
+  };
 }
 
 export function quotaFilesystemUsage(records, temporaryDirectory, maximumBytes, maximumInodes) {
@@ -51,6 +61,7 @@ export function quotaFilesystemUsage(records, temporaryDirectory, maximumBytes, 
         bytes,
         entries,
         symlinks: walked.symlinks,
+        symlink_paths: walked.symlink_paths,
         exceeded: Number(stats.bfree) === 0 || bytes >= maximumBytes
           || entries > maximumInodes || walked.symlinks > 0,
         reason,

--- a/scripts/safe-runner/infrastructure.mjs
+++ b/scripts/safe-runner/infrastructure.mjs
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 const FIXED_DIRECTORIES = Object.freeze(['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin']);
 const MAX_BINARY_BYTES = 256 * 1024 * 1024;
@@ -56,7 +57,7 @@ function binaryDigest(file, size) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
 
-function assertTrustedAncestors(file) {
+function assertTrustedAncestors(file, { requireRootOwnership = false } = {}) {
   let current = path.dirname(file);
   const uid = typeof process.getuid === 'function' ? process.getuid() : null;
   while (true) {
@@ -65,6 +66,7 @@ function assertTrustedAncestors(file) {
     const writableByWorld = (stat.mode & 0o002) !== 0;
     const protectedStickyRoot = writableByWorld && stat.uid === 0 && (stat.mode & 0o1000) !== 0;
     if (!stat.isDirectory() || stat.isSymbolicLink()
+      || (requireRootOwnership && stat.uid !== 0)
       || (uid !== null && stat.uid !== 0 && stat.uid !== uid)
       || (!protectedStickyRoot && (writableByWorld || writableByForeignGroup))) {
       const error = new Error(`trusted executable has an unsafe ancestor: ${current}`);
@@ -77,7 +79,9 @@ function assertTrustedAncestors(file) {
   }
 }
 
-export function trustedBinaryIdentity(candidate, { expectedDigest = null } = {}) {
+export function trustedBinaryIdentity(candidate, {
+  expectedDigest = null, requireRootOwnership = false,
+} = {}) {
   const absolute = path.resolve(candidate);
   const physical = fs.realpathSync.native(absolute);
   if (physical !== absolute) {
@@ -88,13 +92,14 @@ export function trustedBinaryIdentity(candidate, { expectedDigest = null } = {})
   const stat = fs.lstatSync(physical, { bigint: true });
   const uid = typeof process.getuid === 'function' ? process.getuid() : null;
   if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o111n) === 0n
-    || (stat.mode & 0o022n) !== 0n
+    || (stat.mode & 0o6022n) !== 0n
+    || (requireRootOwnership && Number(stat.uid) !== 0)
     || (uid !== null && Number(stat.uid) !== 0 && Number(stat.uid) !== uid)) {
-    const error = new Error(`trusted executable must be a non-writable root/current-user physical file: ${absolute}`);
+    const error = new Error(`trusted executable must be a non-setid, non-writable root/current-user physical file: ${absolute}`);
     error.code = 'LAMINA_SAFE_INFRASTRUCTURE_IDENTITY';
     throw error;
   }
-  assertTrustedAncestors(physical);
+  assertTrustedAncestors(physical, { requireRootOwnership });
   const digest = binaryDigest(physical, Number(stat.size));
   if (expectedDigest && digest !== expectedDigest) {
     const error = new Error(`trusted executable digest mismatch: ${absolute}`);
@@ -106,15 +111,50 @@ export function trustedBinaryIdentity(candidate, { expectedDigest = null } = {})
     dev: String(stat.dev),
     ino: String(stat.ino),
     uid: Number(stat.uid),
-    mode: Number(stat.mode & 0o777n),
+    mode: Number(stat.mode & 0o7777n),
     size: String(stat.size),
     digest,
+    ...(requireRootOwnership ? { nlink: Number(stat.nlink), root_owned_path: true } : {}),
   };
 }
 
+export function trustedRootBinaryIdentity(candidate, { expectedDigest = null } = {}) {
+  const identity = trustedBinaryIdentity(candidate, { expectedDigest, requireRootOwnership: true });
+  let getcap = null;
+  for (const directory of FIXED_DIRECTORIES) {
+    try {
+      getcap = trustedBinaryIdentity(fs.realpathSync.native(path.join(directory, 'getcap')), {
+        requireRootOwnership: true,
+      });
+      break;
+    } catch {}
+  }
+  if (!getcap) {
+    const error = new Error('trusted root-owned getcap is required to attest system executable capabilities');
+    error.code = 'LAMINA_SAFE_INFRASTRUCTURE_IDENTITY';
+    throw error;
+  }
+  const capabilityProbe = spawnSync(getcap.path, ['-n', identity.path], {
+    encoding: 'utf8', env: sanitizedEnvironment(), timeout: 2_000,
+    maxBuffer: 4_096, windowsHide: true,
+  });
+  if (capabilityProbe.error || capabilityProbe.status !== 0 || capabilityProbe.signal
+    || capabilityProbe.stdout.trim() || capabilityProbe.stderr.trim()) {
+    const error = new Error(`trusted root-owned executable must have no file capabilities: ${identity.path}`);
+    error.code = 'LAMINA_SAFE_INFRASTRUCTURE_IDENTITY';
+    throw error;
+  }
+  return { ...identity, file_capabilities: 'empty' };
+}
+
 export function assertTrustedBinaryIdentity(expected) {
-  const actual = trustedBinaryIdentity(expected?.path, { expectedDigest: expected?.digest });
-  for (const field of ['path', 'dev', 'ino', 'uid', 'mode', 'size', 'digest']) {
+  const requireRootOwnership = expected?.root_owned_path === true;
+  const actual = requireRootOwnership
+    ? trustedRootBinaryIdentity(expected?.path, { expectedDigest: expected?.digest })
+    : trustedBinaryIdentity(expected?.path, { expectedDigest: expected?.digest });
+  const fields = ['path', 'dev', 'ino', 'uid', 'mode', 'size', 'digest'];
+  if (requireRootOwnership) fields.push('nlink', 'root_owned_path', 'file_capabilities');
+  for (const field of fields) {
     if (actual[field] !== expected?.[field]) {
       const error = new Error(`trusted executable identity changed before launch: ${expected?.path || 'unknown'}`);
       error.code = 'LAMINA_SAFE_INFRASTRUCTURE_IDENTITY_CHANGED';
@@ -134,6 +174,16 @@ export function trustedHostBinary(name, candidates = FIXED_DIRECTORIES) {
   throw error;
 }
 
+export function trustedRootHostBinary(name, candidates = FIXED_DIRECTORIES) {
+  for (const directory of candidates) {
+    const candidate = path.join(directory, name);
+    try { return trustedRootBinaryIdentity(fs.realpathSync.native(candidate)); } catch {}
+  }
+  const error = new Error(`trusted root-owned infrastructure binary is unavailable: ${name}`);
+  error.code = 'LAMINA_SAFE_INFRASTRUCTURE_IDENTITY';
+  throw error;
+}
+
 let cachedInfrastructure = null;
 export function infrastructureBinaries() {
   if (cachedInfrastructure) return cachedInfrastructure;
@@ -148,7 +198,7 @@ export function infrastructureBinaries() {
     }
     bwrap = trustedBinaryIdentity(pinnedPath, { expectedDigest: pinnedDigest });
   } else {
-    bwrap = trustedHostBinary('bwrap');
+    bwrap = trustedRootHostBinary('bwrap');
   }
   const identities = {
     systemctl: trustedHostBinary('systemctl'),

--- a/scripts/safe-runner/managed-paths.mjs
+++ b/scripts/safe-runner/managed-paths.mjs
@@ -27,13 +27,17 @@ function physicalProcNamespaceDirectory(candidate) {
 function parentIdentity(candidate) {
   const parentPath = path.dirname(candidate);
   const stat = fs.lstatSync(parentPath, { bigint: true });
+  const namespacePrivate = physicalProcNamespaceDirectory(parentPath);
   if (!stat.isDirectory() || stat.isSymbolicLink()
-    || (fs.realpathSync.native(parentPath) !== parentPath
-      && !physicalProcNamespaceDirectory(parentPath))
+    // Resolving /proc/<pid>/root would translate the verified private path
+    // back into the supervisor mount namespace, where it is intentionally
+    // absent. Verify every namespace-private component first and only require
+    // ordinary paths to retain canonical realpath identity.
+    || (!namespacePrivate && fs.realpathSync.native(parentPath) !== parentPath)
     || (typeof process.getuid === 'function' && Number(stat.uid) !== process.getuid())) return null;
   return {
     path: parentPath, dev: String(stat.dev), ino: String(stat.ino), uid: Number(stat.uid),
-    namespace_private: parentPath.startsWith('/proc/'),
+    namespace_private: namespacePrivate,
   };
 }
 

--- a/scripts/safe-runner/managed-paths.mjs
+++ b/scripts/safe-runner/managed-paths.mjs
@@ -9,13 +9,32 @@ export function lstatPresence(candidate) {
   }
 }
 
+function physicalProcNamespaceDirectory(candidate) {
+  const match = path.resolve(candidate).match(/^(\/proc\/[1-9]\d*\/root)(\/.*)$/);
+  if (!match) return false;
+  try {
+    if (!fs.lstatSync(match[1]).isSymbolicLink()) return false;
+    let current = match[1];
+    for (const component of match[2].split('/').filter(Boolean)) {
+      current = path.join(current, component);
+      const stat = fs.lstatSync(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    }
+    return true;
+  } catch { return false; }
+}
+
 function parentIdentity(candidate) {
   const parentPath = path.dirname(candidate);
   const stat = fs.lstatSync(parentPath, { bigint: true });
   if (!stat.isDirectory() || stat.isSymbolicLink()
-    || fs.realpathSync.native(parentPath) !== parentPath
+    || (fs.realpathSync.native(parentPath) !== parentPath
+      && !physicalProcNamespaceDirectory(parentPath))
     || (typeof process.getuid === 'function' && Number(stat.uid) !== process.getuid())) return null;
-  return { path: parentPath, dev: String(stat.dev), ino: String(stat.ino), uid: Number(stat.uid) };
+  return {
+    path: parentPath, dev: String(stat.dev), ino: String(stat.ino), uid: Number(stat.uid),
+    namespace_private: parentPath.startsWith('/proc/'),
+  };
 }
 
 function sameParent(candidate, expected) {

--- a/scripts/safe-runner/preflight.mjs
+++ b/scripts/safe-runner/preflight.mjs
@@ -18,6 +18,11 @@ import { optionalAuditedNpxCommand } from './npx-authority.mjs';
 import { repositoryOutputRefusal } from './output-policy.mjs';
 import { retrievalQualificationAuthority } from './retrieval-authority.mjs';
 import {
+  assertScenario as assertRuntimeBaselineScenario,
+  fixtureById as runtimeBaselineFixtureById,
+  loadManifest as loadRuntimeBaselineManifest,
+} from '../../benchmarks/runtime-baseline-v1/contract.mjs';
+import {
   checkPromotion, checkSafetyRetry, frozenWorkloadIdentity, productionLockDirectory,
   readAttestation, stateDirectory,
 } from './state.mjs';
@@ -30,9 +35,11 @@ const EXTERNAL_DAEMON_ENTRYPOINTS = [
 
 const EXTERNAL_TEXT = /(?:^|[\s;&|/"'])(?:docker|podman|harbor)(?=$|[\s;&|/"'])/i;
 const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+export const RUNTIME_BASELINE_ENTRYPOINT = 'benchmarks/runtime-baseline-v1/workload.mjs';
 
 const AUDITED_NODE_ENTRYPOINTS = new Map([
   ['benchmarks/retrieval-v1/benchmark.mjs', false],
+  [RUNTIME_BASELINE_ENTRYPOINT, true],
   ['benchmarks/runtime-v1/fixture/tiny-runtime.mjs', false],
   ['evals/scripts/run-suite.mjs', true],
   ['evals/scripts/run-reference-matrix.mjs', true],
@@ -142,6 +149,37 @@ function trustedExecutable(command, cwd, expected) {
   });
 }
 
+function ignoredRuntimeBaselineInput(argument, expected, { executable = false } = {}) {
+  const declared = path.resolve(REPOSITORY_ROOT, String(argument || ''));
+  const relative = path.relative(REPOSITORY_ROOT, declared).replaceAll('\\', '/');
+  if (!relative || relative.startsWith('../') || path.isAbsolute(relative)) return false;
+  try {
+    const physical = fs.realpathSync.native(declared);
+    const stat = fs.lstatSync(declared);
+    if (physical !== declared || !stat.isFile() || stat.isSymbolicLink()
+      || stat.size !== expected.bytes
+      || (typeof process.getuid === 'function' && stat.uid !== process.getuid())
+      || (executable && (stat.mode & 0o111) === 0)) return false;
+    const ignored = spawnTrustedGit(REPOSITORY_ROOT, ['check-ignore', '--quiet', '--', relative], {
+      encoding: 'utf8', stdio: ['ignore', 'ignore', 'ignore'], timeout: 2_000,
+      maxBuffer: 8 * 1024,
+    });
+    return ignored.status === 0;
+  } catch { return false; }
+}
+
+export function auditedRuntimeBaselineCommand(command = [], cwd = process.cwd()) {
+  if (command.length !== 7 || command[2] !== 'run') return false;
+  try {
+    runtimeBaselineFixtureById(command[3]);
+    assertRuntimeBaselineScenario(command[4]);
+    const { manifest } = loadRuntimeBaselineManifest();
+    return ignoredRuntimeBaselineInput(path.resolve(cwd, command[5]), manifest.runtime_assets.model)
+      && ignoredRuntimeBaselineInput(path.resolve(cwd, command[6]),
+        manifest.runtime_assets.worker_linux_x64, { executable: true });
+  } catch { return false; }
+}
+
 export function auditedCommand(command = [], cwd = process.cwd()) {
   const executable = path.basename(String(command[0] || '')).toLowerCase();
   if (/^node(?:\.exe)?$/.test(executable)) {
@@ -152,6 +190,10 @@ export function auditedCommand(command = [], cwd = process.cwd()) {
     const entrypoint = command[1];
     const relative = entrypoint && !String(entrypoint).startsWith('-')
       ? auditedRepositoryFile(path.resolve(cwd, entrypoint), AUDITED_NODE_ENTRYPOINTS) : null;
+    if (relative === RUNTIME_BASELINE_ENTRYPOINT
+      && !auditedRuntimeBaselineCommand(command, cwd)) {
+      return { audited: false, allow_network: false, entrypoint: relative };
+    }
     return relative !== null
       ? { audited: true, allow_network: AUDITED_NODE_ENTRYPOINTS.get(relative), entrypoint: relative,
         executable: resolved }

--- a/scripts/safe-runner/processes.mjs
+++ b/scripts/safe-runner/processes.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { isExecutionHookEnvironment } from './infrastructure.mjs';
 
 export const MAX_PROCESS_ENVIRONMENT_BYTES = 64 * 1024;
@@ -78,6 +79,7 @@ export function processRecord(pid) {
     const stat = parseProcStat(fs.readFileSync(`/proc/${pid}/stat`, 'utf8'));
     const status = fs.readFileSync(`/proc/${pid}/status`, 'utf8');
     const rss = Number(status.match(/^VmRSS:\s+(\d+)\s+kB$/m)?.[1] || 0) * 1024;
+    const threads = Number(status.match(/^Threads:\s+(\d+)$/m)?.[1] || 0);
     const namespacePids = String(status.match(/^NSpid:\s+(.+)$/m)?.[1] || '')
       .trim().split(/\s+/).filter(Boolean).map(Number);
     const cmdlineBytes = fs.readFileSync(`/proc/${pid}/cmdline`);
@@ -86,7 +88,15 @@ export function processRecord(pid) {
     const cmdline = (argv || []).join(' ');
     const environmentAttestation = readProcessEnvironment(pid);
     let cwd = null;
-    try { cwd = fs.realpathSync.native(`/proc/${pid}/cwd`); } catch {}
+    try {
+      // /proc/<pid>/cwd already reports the resolved path in that process's
+      // mount namespace. realpath would incorrectly re-resolve the target in
+      // the supervisor namespace, where a private tmpfs path is absent.
+      const namespaceCwd = fs.readlinkSync(`/proc/${pid}/cwd`);
+      if (path.isAbsolute(namespaceCwd) && !namespaceCwd.endsWith(' (deleted)')) {
+        cwd = path.resolve(namespaceCwd);
+      }
+    } catch {}
     let executableIdentity = null;
     try {
       const executable = fs.statSync(`/proc/${pid}/exe`, { bigint: true });
@@ -100,6 +110,7 @@ export function processRecord(pid) {
       start_ticks: stat?.start_ticks ?? null,
       state: stat?.state ?? null,
       rss_bytes: rss,
+      threads,
       namespace_pids: namespacePids,
       command: cmdline.slice(0, 1_000),
       argv,

--- a/scripts/safe-runner/runner.mjs
+++ b/scripts/safe-runner/runner.mjs
@@ -90,6 +90,46 @@ export function temporaryQuotaHandshakeFailure(childEnded, launcherStderr = '') 
   };
 }
 
+export function resolvePrivateManagedGraphdPaths({
+  requester, socket, lock, launchAuthority = [], procRoot = '/proc',
+} = {}) {
+  const canonicalSocket = path.resolve(String(socket || ''));
+  const canonicalLock = path.resolve(String(lock || ''));
+  if (!Number.isSafeInteger(requester?.pid) || requester.pid <= 1
+    || typeof requester?.start_ticks !== 'string' || !requester.start_ticks
+    || !path.isAbsolute(socket || '') || !path.isAbsolute(lock || '')
+    || path.dirname(canonicalSocket) !== path.dirname(canonicalLock)
+    || path.basename(canonicalSocket) !== 'graphd.sock'
+    || path.basename(canonicalLock) !== 'graphd.lock') return null;
+  const privateAuthorities = launchAuthority.filter((item) =>
+    item?.kind === 'exact' && typeof item.private_tmp_root === 'string');
+  if (privateAuthorities.length === 0) {
+    return { socket: canonicalSocket, lock: canonicalLock };
+  }
+  const matched = privateAuthorities.find((item) => {
+    const privateRoot = path.resolve(item.private_tmp_root);
+    const runtime = path.resolve(item.runtime_directory);
+    const relative = path.relative(privateRoot, runtime);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+      && canonicalSocket === path.join(runtime, 'graphd.sock')
+      && canonicalLock === path.join(runtime, 'graphd.lock');
+  });
+  if (!matched) return null;
+  const namespaceRoot = path.join(path.resolve(procRoot), String(requester.pid), 'root');
+  try {
+    if (!fs.lstatSync(namespaceRoot).isSymbolicLink()) return null;
+  } catch { return null; }
+  const translatedParent = path.join(namespaceRoot,
+    path.dirname(canonicalSocket).replace(/^\/+/, ''));
+  let parentStat;
+  try { parentStat = fs.lstatSync(translatedParent); } catch { return null; }
+  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) return null;
+  return {
+    socket: path.join(translatedParent, 'graphd.sock'),
+    lock: path.join(translatedParent, 'graphd.lock'),
+  };
+}
+
 export function recordChildTermination(termination, childEnded) {
   termination.child_exit_code = Number.isInteger(childEnded?.code) ? childEnded.code : null;
   termination.child_signal = typeof childEnded?.signal === 'string' && childEnded.signal
@@ -636,6 +676,12 @@ export async function runSafely({
       graphdLaunchAuthorized(child, reservation) {
         return exactGraphdLaunchAuthorized(child, reservation,
           executionSnapshot?.graphd_launch_authority || []);
+      },
+      resolveManagedGraphdPaths({ requester, socket, lock }) {
+        return resolvePrivateManagedGraphdPaths({
+          requester, socket, lock,
+          launchAuthority: executionSnapshot?.graphd_launch_authority || [],
+        });
       },
       beforeBind() {
         // The graphd process exists but is still held behind its broker start

--- a/scripts/safe-runner/runner.mjs
+++ b/scripts/safe-runner/runner.mjs
@@ -252,6 +252,7 @@ function rememberDescendants(report, records, elapsedMs) {
       first_seen_ms: existing?.first_seen_ms ?? elapsedMs,
       last_seen_ms: elapsedMs,
       peak_rss_bytes: Math.max(existing?.peak_rss_bytes || 0, record.rss_bytes || 0),
+      peak_threads: Math.max(existing?.peak_threads || 0, record.threads || 0),
     });
   }
   report.descendants = [...known.values()]
@@ -476,6 +477,13 @@ export async function runSafely({
       const temporaryLimit = temporary.reason === 'inodes'
         ? 'temporary_inodes'
         : temporary.reason === 'symlink' ? 'temporary_symlink' : 'temporary_disk';
+      if (temporaryLimit === 'temporary_symlink') {
+        report.preflight.temporary_limit_diagnostic = {
+          reason: temporaryLimit,
+          symlink_count: temporary.symlinks,
+          symlink_paths: temporary.symlink_paths || [],
+        };
+      }
       requestStop('safety_limit_exceeded', temporaryLimit);
     }
     const highEvents = measured.events?.memory?.high || 0;

--- a/scripts/safe-runner/sandbox.mjs
+++ b/scripts/safe-runner/sandbox.mjs
@@ -44,6 +44,7 @@ const SEALED_ENVIRONMENT_NAMES_BY_ENTRYPOINT = new Map([
     'LAMINA_RETRIEVAL_VECTOR_EXTENSION_PATH',
   ])],
 ]);
+const RUNTIME_BASELINE_ENTRYPOINT = 'benchmarks/runtime-baseline-v1/workload.mjs';
 
 const STANDARD_CONTROL_SOCKETS = Object.freeze([
   '/run/dbus/system_bus_socket',
@@ -185,8 +186,9 @@ export function validatedSealedEnvironmentNames({
 }
 
 export function validatedSealedGitIdentity(executionAuthority) {
-  const graphdFixture = executionAuthority?.audited_entrypoint
-    === 'tests/fixtures/safe-runner-graphd-client.mjs';
+  const graphdFixture = [
+    'tests/fixtures/safe-runner-graphd-client.mjs', RUNTIME_BASELINE_ENTRYPOINT,
+  ].includes(executionAuthority?.audited_entrypoint);
   const expected = executionAuthority?.git_executable_identity;
   if (!graphdFixture) {
     if (expected !== null && expected !== undefined) {
@@ -253,6 +255,18 @@ export function validateSandboxExecutionAuthority({
         || fs.realpathSync.native(binding.target) !== binding.target;
     } catch { return true; }
   };
+  const runtimeBaselineInvalid = (() => {
+    if (executionAuthority?.audited_entrypoint !== RUNTIME_BASELINE_ENTRYPOINT) return false;
+    const workerOverlay = path.join(
+      executionAuthority.snapshot_repository,
+      'packages/cli/observation-runtime/cocoindex-worker',
+    );
+    try {
+      const worker = fs.lstatSync(workerOverlay);
+      return executionAuthority.writable_bindings.length !== 0
+        || !worker.isFile() || worker.isSymbolicLink() || (worker.mode & 0o111) === 0;
+    } catch { return true; }
+  })();
   if (!path.isAbsolute(executionAuthority?.repository || '')
     || !path.isAbsolute(executionAuthority?.snapshot_repository || '')
     || !path.isAbsolute(executionAuthority?.git_common || '')
@@ -263,7 +277,8 @@ export function validateSandboxExecutionAuthority({
     || !Array.isArray(executionAuthority?.writable_bindings)
     || executionAuthority.writable_bindings.some(invalidBinding)
     || !Array.isArray(executionAuthority?.git_readonly_bindings)
-    || executionAuthority.git_readonly_bindings.some(invalidGitBinding)) {
+    || executionAuthority.git_readonly_bindings.some(invalidGitBinding)
+    || runtimeBaselineInvalid) {
     throw new Error('safe-runner sandbox received an invalid execution authority');
   }
   let sealedGitIdentity;

--- a/scripts/safe-runner/sandbox.mjs
+++ b/scripts/safe-runner/sandbox.mjs
@@ -322,14 +322,26 @@ async function main() {
     process.stderr.write(`safe-runner bwrap identity changed: ${error.code || error.message}\n`);
     process.exit(125);
   }
-  const child = spawn(bwrapExecutable, bubblewrapSandboxArguments({
+  const bwrapArguments = bubblewrapSandboxArguments({
     cwd, readyFile, releaseFile, temporaryDirectory, command,
     executionAuthority,
     sealedGitIdentity: sandboxContract.sealedGitIdentity,
     preservedEnvironmentNames: sandboxContract.preservedEnvironmentNames,
     environment: process.env,
     allowNetwork: process.env.LAMINA_SAFE_RUNNER_ALLOW_NETWORK === '1',
-  }), { stdio: 'inherit', env: sanitizedEnvironment(process.env) });
+  });
+  const bwrapEnvironment = sanitizedEnvironment(process.env);
+  if (typeof process.execve === 'function') {
+    try {
+      process.execve(bwrapExecutable, [bwrapExecutable, ...bwrapArguments], bwrapEnvironment);
+    } catch (error) {
+      process.stderr.write(`safe-runner sandbox exec failed: ${error.code || error.message}\n`);
+      process.exit(125);
+    }
+  }
+  const child = spawn(bwrapExecutable, bwrapArguments, {
+    stdio: 'inherit', env: bwrapEnvironment,
+  });
   for (const signal of ['SIGTERM', 'SIGINT']) {
     process.on(signal, () => {
       try { child.kill(signal); } catch {}

--- a/scripts/safe-runner/state.mjs
+++ b/scripts/safe-runner/state.mjs
@@ -238,6 +238,92 @@ export function workloadIdentity(cwd, command = []) {
   return files;
 }
 
+export function sealedManifestFileIdentity(file, expected, role = 'input') {
+  let descriptor = null;
+  try {
+    if (!Number.isSafeInteger(expected?.bytes)
+      || !/^[a-f0-9]{64}$/.test(expected?.sha256 || '')) {
+      throw new Error('invalid manifest input');
+    }
+    const named = fs.lstatSync(file, { bigint: true });
+    if (!named.isFile() || named.isSymbolicLink()
+      || named.size !== BigInt(expected.bytes)
+      || fs.realpathSync.native(file) !== file) throw new Error('input is not physical');
+    descriptor = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const opened = fs.fstatSync(descriptor, { bigint: true });
+    if (opened.dev !== named.dev || opened.ino !== named.ino || opened.size !== named.size
+      || opened.uid !== named.uid || opened.mode !== named.mode || opened.nlink !== named.nlink) {
+      throw new Error('input changed while opening');
+    }
+    const hash = crypto.createHash('sha256');
+    const buffer = Buffer.alloc(1024 * 1024);
+    let offset = 0;
+    while (offset < Number(opened.size)) {
+      const bytes = fs.readSync(descriptor, buffer, 0, buffer.length, offset);
+      if (bytes === 0) break;
+      hash.update(buffer.subarray(0, bytes));
+      offset += bytes;
+    }
+    const final = fs.fstatSync(descriptor, { bigint: true });
+    const digest = hash.digest('hex');
+    if (offset !== expected.bytes || digest !== expected.sha256
+      || final.dev !== opened.dev || final.ino !== opened.ino || final.size !== opened.size
+      || final.uid !== opened.uid || final.mode !== opened.mode || final.nlink !== opened.nlink) {
+      throw new Error('input bytes changed or contradict the manifest');
+    }
+    return {
+      role, digest, size: String(opened.size), dev: String(opened.dev),
+      ino: String(opened.ino), uid: Number(opened.uid),
+      mode: Number(opened.mode & 0o777n), nlink: Number(opened.nlink),
+    };
+  } catch {
+    const error = new Error(`runtime baseline ${role} input failed sealed manifest identity`);
+    error.code = 'LAMINA_SAFE_SOURCE_IDENTITY';
+    throw error;
+  } finally { if (descriptor !== null) fs.closeSync(descriptor); }
+}
+
+function runtimeBaselineInputIdentity(cwd, command) {
+  const entrypoint = path.resolve(cwd, String(command[1] || ''));
+  if (!entrypoint.replaceAll('\\', '/').endsWith('/benchmarks/runtime-baseline-v1/workload.mjs')) {
+    return null;
+  }
+  if (command.length !== 7 || command[2] !== 'run') {
+    const error = new Error('runtime baseline identity requires its exact audited command');
+    error.code = 'LAMINA_SAFE_SOURCE_IDENTITY';
+    throw error;
+  }
+  const repository = path.resolve(path.dirname(entrypoint), '../..');
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(
+      path.join(repository, 'benchmarks/runtime-baseline-v1/manifest.json'), 'utf8',
+    ));
+  } catch {
+    const error = new Error('runtime baseline manifest identity is unavailable');
+    error.code = 'LAMINA_SAFE_SOURCE_IDENTITY';
+    throw error;
+  }
+  const definitions = [
+    { index: 5, role: 'model', expected: manifest?.runtime_assets?.model },
+    { index: 6, role: 'worker', expected: manifest?.runtime_assets?.worker_linux_x64 },
+  ];
+  const inputs = [];
+  for (const definition of definitions) {
+    const file = path.resolve(cwd, String(command[definition.index] || ''));
+    const relative = path.relative(repository, file).replaceAll('\\', '/');
+    if (!relative || relative.startsWith('../') || path.isAbsolute(relative)) {
+      const error = new Error(`runtime baseline ${definition.role} input failed sealed manifest identity`);
+      error.code = 'LAMINA_SAFE_SOURCE_IDENTITY';
+      throw error;
+    }
+    inputs.push({
+      ...sealedManifestFileIdentity(file, definition.expected, definition.role), relative,
+    });
+  }
+  return inputs;
+}
+
 function executableIdentity(candidate, maximumBytes = 256 * 1024 * 1024) {
   let descriptor = null;
   try {
@@ -363,8 +449,11 @@ export function frozenWorkloadIdentity(cwd, command) {
     repository: normalizedCwd, cwd: normalizedCwd, command: normalizedCommand,
   });
   const retrievalValueIndexes = new Set(retrievalAuthority?.argument_value_indexes || []);
+  const runtimeBaselineInputs = runtimeBaselineInputIdentity(normalizedCwd, normalizedCommand);
+  const runtimeBaselineValueIndexes = new Set(runtimeBaselineInputs ? [5, 6] : []);
   const genericWorkloadArguments = normalizedCommand.slice(1).filter(
-    (_argument, index) => !retrievalValueIndexes.has(index + 1),
+    (_argument, index) => !retrievalValueIndexes.has(index + 1)
+      && !runtimeBaselineValueIndexes.has(index + 1),
   );
   const value = {
     repository: normalizedCwd,
@@ -379,6 +468,7 @@ export function frozenWorkloadIdentity(cwd, command) {
       model: retrievalAuthority.model,
       tokenizer: retrievalAuthority.tokenizer,
     } : null,
+    runtime_baseline_inputs: runtimeBaselineInputs,
     repository_source: commandSourceDigest(normalizedCwd, normalizedCommand),
     runner_build: runnerBuildDigest(),
   };

--- a/tests/graphd_long_socket_test.mjs
+++ b/tests/graphd_long_socket_test.mjs
@@ -38,13 +38,51 @@ try {
     assert.equal(fs.realpathSync(path.dirname(childEndpoint)), fs.realpathSync(paths.runtime_dir));
     if (fs.existsSync('/proc/self/fd')) {
       assert.match(endpoint, /^\/proc\/self\/fd\/\d+\/graphd\.sock$/);
-      assert.doesNotMatch(childEndpoint, /^\/proc\/self\/fd\//);
+      assert.match(childEndpoint, new RegExp(`^/proc/${process.pid}/fd/\\d+/graphd\\.sock$`));
+      const childResolved = execFileSync(process.execPath, ['-e',
+        'process.stdout.write(require("node:fs").realpathSync(process.env.ENDPOINT_DIRECTORY))'], {
+        env: { ...process.env, ENDPOINT_DIRECTORY: path.dirname(childEndpoint) },
+        encoding: 'utf8',
+      });
+      assert.equal(childResolved, fs.realpathSync(paths.runtime_dir),
+        'an exec child must reach the canonical runtime directory through the parent descriptor');
     }
   }
   const status = await graphRequest('status', {}, root);
   assert.equal(status.branch, 'main');
   if (process.platform !== 'win32') {
     assert.ok(fs.existsSync(paths.socket), 'short alias must still create the canonical clone-local socket entry');
+    if (fs.existsSync('/proc/self/fd')) {
+      const childResponse = execFileSync(process.execPath, ['-e', `
+        const fs = require('node:fs');
+        const net = require('node:net');
+        const socket = net.createConnection(process.env.ENDPOINT);
+        let received = '';
+        socket.setEncoding('utf8');
+        socket.setTimeout(2000, () => socket.destroy(new Error('timeout')));
+        socket.on('connect', () => socket.write(JSON.stringify({
+          id: 'long-socket-child', method: 'status', params: {},
+          cwd: process.env.REPOSITORY,
+          auth: fs.readFileSync(process.env.TOKEN, 'utf8').trim(),
+        }) + '\\n'));
+        socket.on('data', (chunk) => {
+          received += chunk;
+          if (!received.includes('\\n')) return;
+          const response = JSON.parse(received.slice(0, received.indexOf('\\n')));
+          if (!response.ok) throw new Error(response.error?.message || 'request refused');
+          process.stdout.write(JSON.stringify(response.result));
+          socket.end();
+        });
+        socket.on('error', (error) => { console.error(error.message); process.exit(2); });
+      `], {
+        env: {
+          ...process.env, ENDPOINT: childEndpoint, REPOSITORY: root, TOKEN: paths.token,
+        },
+        encoding: 'utf8', timeout: 5_000,
+      });
+      assert.equal(JSON.parse(childResponse).branch, 'main',
+        'an exec child must complete a graph request through the parent descriptor endpoint');
+    }
   }
   const pid = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8'))?.pid;
   if (Number.isInteger(pid) && pid > 1) await stopIncompatibleServer(paths, pid);

--- a/tests/graphd_long_socket_test.mjs
+++ b/tests/graphd_long_socket_test.mjs
@@ -29,6 +29,11 @@ try {
   const paths = runtimePaths(root);
   const endpoint = graphSocketPath(paths);
   const childEndpoint = graphSocketChildPath(paths);
+  if (process.platform !== 'win32') {
+    const fallbackEndpoint = graphSocketPath(paths, 'darwin');
+    assert.equal(graphSocketChildPath(paths, 'darwin'), fallbackEndpoint,
+      'repeated fallback alias resolution must retain one canonical live target');
+  }
   if (process.platform === 'win32') {
     assert.match(endpoint, /^\\\\\.\\pipe\\laminadev-[a-f0-9]{24}$/);
   } else {

--- a/tests/runtime_baseline_test.mjs
+++ b/tests/runtime_baseline_test.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  COLD_RUNS,
+  fixtureById,
+  loadManifest,
+  SCENARIOS,
+  summarizeNanoseconds,
+  WARM_SAMPLES,
+  WORKLOAD_SCHEMA,
+} from '../benchmarks/runtime-baseline-v1/contract.mjs';
+import { validateWorkloadRecord } from '../benchmarks/runtime-baseline-v1/validate.mjs';
+
+const { manifest, digest } = loadManifest();
+assert.equal(manifest.fixtures.length, 3);
+assert.deepEqual(manifest.fixtures.map((item) => item.id), ['small', 'medium', 'large']);
+assert.match(digest, /^[a-f0-9]{64}$/);
+assert.equal(new Set(manifest.fixtures.map((item) => item.commit)).size, 3);
+assert.ok(manifest.fixtures.every((item) => /^[a-f0-9]{40}$/.test(item.commit)));
+assert.ok(manifest.fixtures.every((item) => item.url.startsWith('https://github.com/')));
+assert.equal(fixtureById('large').polyglot, true);
+assert.throws(() => fixtureById('../large'), /unknown runtime baseline fixture/);
+assert.equal(SCENARIOS.length, 12);
+
+const cold = summarizeNanoseconds([30, 10, 20], false);
+assert.deepEqual(cold, { count: 3, median: 20, maximum: 30, p90: null, p95: null });
+const warmValues = Array.from({ length: WARM_SAMPLES }, (_, index) => index + 1);
+const warm = summarizeNanoseconds(warmValues, true);
+assert.equal(warm.count, 30);
+assert.equal(warm.p90, 27);
+assert.equal(warm.p95, 29);
+
+const fixture = manifest.fixtures[0];
+const record = {
+  schema: WORKLOAD_SCHEMA,
+  manifest_digest: digest,
+  fixture: {
+    id: fixture.id, name: fixture.name, url: fixture.url, commit: fixture.commit,
+    class: fixture.class, languages: fixture.languages, polyglot: false,
+  },
+  scenario: 'doctor-status-startup',
+  runtime: { node: process.version, lamina_commit: 'a'.repeat(40), assets_release: 'cli-v0.3.5' },
+  samples: Array.from({ length: COLD_RUNS }, (_, index) => ({
+    index, wall_time_ns: index + 1, diagnostics: {},
+    cleanup: { repository_removed: true, socket_removed: true, lock_removed: true },
+  })),
+  statistics: summarizeNanoseconds([1, 2, 3], false),
+  classification: 'cold',
+  repository: {
+    commit: fixture.commit,
+    tracked_files: 100,
+    tracked_bytes: 1000,
+    tracked_source_files: 80,
+    tracked_source_bytes: 800,
+    tracked_source_loc: 20000,
+    indexed_candidate_files: 90,
+    indexed_candidate_bytes: 900,
+    exclusion_rules: manifest.exclusions,
+    indexed_paths_digest: 'b'.repeat(64),
+  },
+  diagnostics: [{}, {}, {}],
+  cleanup: { repository_removed: true, socket_removed: true, lock_removed: true },
+};
+assert.deepEqual(validateWorkloadRecord(record, {
+  fixtureId: 'small', scenario: 'doctor-status-startup',
+}), { valid: true, errors: [] });
+
+const mislabeled = structuredClone(record);
+mislabeled.statistics.p95 = 3;
+assert.equal(validateWorkloadRecord(mislabeled).valid, false);
+const stalePin = structuredClone(record);
+stalePin.fixture.commit = 'c'.repeat(40);
+assert.equal(validateWorkloadRecord(stalePin).valid, false);
+const incompleteCleanup = structuredClone(record);
+incompleteCleanup.cleanup.socket_removed = false;
+assert.equal(validateWorkloadRecord(incompleteCleanup).valid, false);
+
+assert.doesNotThrow(() => fs.accessSync(path.resolve('benchmarks/runtime-baseline-v1/workload.mjs')));
+console.log('runtime_baseline_test: ok');

--- a/tests/runtime_baseline_test.mjs
+++ b/tests/runtime_baseline_test.mjs
@@ -55,10 +55,16 @@ const record = {
     tracked_source_files: 80,
     tracked_source_bytes: 800,
     tracked_source_loc: 20000,
-    indexed_candidate_files: 90,
-    indexed_candidate_bytes: 900,
+    observation_indexed_files: 90,
+    observation_indexed_bytes: 900,
+    retrieval_candidate_files: 70,
+    retrieval_candidate_bytes: 700,
+    retrieval_indexed_files: 70,
+    retrieval_indexed_bytes: 700,
+    retrieval_source_chunks: 140,
     exclusion_rules: manifest.exclusions,
-    indexed_paths_digest: 'b'.repeat(64),
+    observation_paths_digest: 'b'.repeat(64),
+    retrieval_paths_digest: 'c'.repeat(64),
   },
   diagnostics: [{}, {}, {}],
   cleanup: { repository_removed: true, socket_removed: true, lock_removed: true },
@@ -76,6 +82,11 @@ assert.equal(validateWorkloadRecord(stalePin).valid, false);
 const incompleteCleanup = structuredClone(record);
 incompleteCleanup.cleanup.socket_removed = false;
 assert.equal(validateWorkloadRecord(incompleteCleanup).valid, false);
+const coldSample = structuredClone(record);
+coldSample.classification = 'cold-sample';
+coldSample.samples = [coldSample.samples[0]];
+coldSample.statistics = null;
+assert.equal(validateWorkloadRecord(coldSample).valid, true);
 
 assert.doesNotThrow(() => fs.accessSync(path.resolve('benchmarks/runtime-baseline-v1/workload.mjs')));
 console.log('runtime_baseline_test: ok');

--- a/tests/runtime_benchmark_test.mjs
+++ b/tests/runtime_benchmark_test.mjs
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { baseReport, validateReport } from '../scripts/safe-runner/report.mjs';
 import { parseCgroupCpuStat, parseCgroupIoStat } from '../scripts/safe-runner/linux-systemd.mjs';
 import {
@@ -15,12 +16,16 @@ import {
 } from '../benchmarks/runtime-v1/harness.mjs';
 import { fixtureMetadata } from '../benchmarks/runtime-v1/fixture-metadata.mjs';
 import { benchmarkIdentity } from '../benchmarks/runtime-v1/identity.mjs';
+import { readBoundedPhysicalFile } from '../benchmarks/runtime-v1/physical-files.mjs';
 import { median, nearestRank, summarizeLatency } from '../benchmarks/runtime-v1/statistics.mjs';
 import { classifySafeRunnerOutcome, validateResult } from '../benchmarks/runtime-v1/validate.mjs';
 
 const digest = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
 const clone = (value) => structuredClone(value);
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lamina-runtime-benchmark-test-'));
+const trackedRepositorySymlink = fileURLToPath(
+  new URL('../evals/fixtures/_base/outline/CLAUDE.md', import.meta.url),
+);
 
 function successfulSafeReport(index) {
   const report = baseReport({ tier: 'small', command: ['node', 'tiny-runtime.mjs'], cwd: '/fixture' });
@@ -248,6 +253,10 @@ function mutateFixtureRecord(raw, mutate) {
 }
 
 try {
+  assert.equal(fs.lstatSync(trackedRepositorySymlink).isSymbolicLink(), true);
+  assert.equal(fs.readlinkSync(trackedRepositorySymlink), 'AGENTS.md');
+  assert.equal(fs.statSync(trackedRepositorySymlink).isFile(), true);
+
   assert.equal(median([4, 1, 3, 2]), 2.5);
   assert.equal(nearestRank([1, 2, 3, 4, 5], 0.95), 5);
   assert.deepEqual(summarizeLatency([3, 1, 2], 'cold'), {
@@ -314,16 +323,10 @@ try {
     /single-link physical file/,
   );
   fs.unlinkSync(hardlink);
-  const warmTelemetry = path.join(owned.root, 'telemetry', 'warm.json');
-  const warmTelemetryBackup = path.join(root, 'warm-telemetry-backup.json');
-  fs.renameSync(warmTelemetry, warmTelemetryBackup);
-  fs.symlinkSync(warmTelemetryBackup, warmTelemetry);
-  assert.match(
-    validateResult(result, { artifactRoot: owned.root }).errors.join('; '),
+  assert.throws(
+    () => readBoundedPhysicalFile(trackedRepositorySymlink, 128 * 1024),
     /physical file|ELOOP/,
   );
-  fs.unlinkSync(warmTelemetry);
-  fs.renameSync(warmTelemetryBackup, warmTelemetry);
   const partial = clone(result);
   partial.series[1].samples.pop();
   partial.series[1].measured_count = 29;
@@ -474,12 +477,10 @@ try {
   fs.unlinkSync(path.join(foreign.root, 'telemetry', 'foreign.json'));
   cleanupHarnessRoot(foreign.root);
 
-  const symlinkTarget = initializeHarnessRoot(path.join(root, 'target'));
-  const symlink = path.join(root, 'link');
-  fs.symlinkSync(symlinkTarget.root, symlink);
-  assert.throws(() => cleanupHarnessRoot(symlink), /physical directory|symlink indirection/);
-  fs.unlinkSync(symlink);
-  cleanupHarnessRoot(symlinkTarget.root);
+  assert.throws(
+    () => cleanupHarnessRoot(trackedRepositorySymlink),
+    /physical directory|symlink indirection/,
+  );
 
   assert.throws(() => initializeHarnessRoot(path.resolve('.runtime-benchmark-forbidden')), /outside/);
   process.stdout.write('runtime benchmark unit tests passed\n');

--- a/tests/safe_runner_test.mjs
+++ b/tests/safe_runner_test.mjs
@@ -18,7 +18,9 @@ import {
   parseHostPageSize,
   validateLimitOverrides,
 } from '../scripts/safe-runner/envelope.mjs';
-import { ownedDirectoryIdentity, removeOwnedDirectory } from '../scripts/safe-runner/filesystem.mjs';
+import {
+  boundedDirectorySize, ownedDirectoryIdentity, removeOwnedDirectory,
+} from '../scripts/safe-runner/filesystem.mjs';
 import {
   assertSystemctlSuccess,
   cgroupResolutionState,
@@ -42,7 +44,7 @@ import {
 import {
   assertTrustedBinaryIdentity, infrastructureBinaries, isExecutionHookEnvironment,
   SAFE_INFRASTRUCTURE_PATH, sanitizedEnvironment, sanitizedPayloadEnvironment,
-  trustedBinaryIdentity, trustedHostBinary,
+  trustedBinaryIdentity, trustedHostBinary, trustedRootBinaryIdentity,
 } from '../scripts/safe-runner/infrastructure.mjs';
 import { commandOwnership, preflightRun, writableWorktreeProof } from '../scripts/safe-runner/preflight.mjs';
 import {
@@ -54,7 +56,7 @@ import {
   assertGitObjectClosureBudget, auditedNpxPackage, dependencyPackageTarget,
   measureAuditedNpxPackageClosure, measureInstalledPackageClosure,
   measurePhysicalPackageTree, packageName, prepareExecutionSnapshot,
-  readBoundedPackageManifest,
+  readBoundedPackageManifest, requiresSystemBwrapPath,
 } from '../scripts/safe-runner/execution-snapshot.mjs';
 import { auditedNpxCommand } from '../scripts/safe-runner/npx-authority.mjs';
 import { repositoryOutputRefusal } from '../scripts/safe-runner/output-policy.mjs';
@@ -513,6 +515,62 @@ try {
   assert.equal(assertTrustedBinaryIdentity(binaryIdentity).path, binaryCopy);
   fs.appendFileSync(binaryCopy, 'changed');
   assert.throws(() => assertTrustedBinaryIdentity(binaryIdentity), /digest mismatch|identity changed/);
+  assert.equal(requiresSystemBwrapPath({
+    bwrap: '/usr/bin/bwrap', pinned_bwrap: false,
+    identities: { bwrap: { path: '/usr/bin/bwrap', uid: 0, root_owned_path: true } },
+  }), true, 'an unpinned root-owned distribution bwrap must keep its LSM-visible path');
+  assert.equal(requiresSystemBwrapPath({
+    bwrap: '/tmp/bwrap', pinned_bwrap: true,
+    identities: { bwrap: { path: '/tmp/bwrap', uid: 0, root_owned_path: true } },
+  }), false, 'an explicitly pinned bwrap must retain descriptor-copy authority');
+  assert.equal(requiresSystemBwrapPath({
+    bwrap: '/tmp/bwrap', pinned_bwrap: false,
+    identities: { bwrap: { path: '/tmp/bwrap', uid: process.getuid?.(), root_owned_path: false } },
+  }), false, 'a current-user bwrap must never bypass descriptor-copy authority');
+  if (infrastructureBinaries().pinned_bwrap === false) {
+    const rootBwrap = trustedRootBinaryIdentity(infrastructureBinaries().bwrap);
+    assert.equal(rootBwrap.root_owned_path, true);
+    assert.equal(rootBwrap.path, infrastructureBinaries().bwrap);
+    assert.deepEqual(assertTrustedBinaryIdentity(rootBwrap), rootBwrap,
+      'root-owned path authority must revalidate root ownership and link identity');
+    assert.equal(requiresSystemBwrapPath(infrastructureBinaries()), true);
+  }
+  const setidCopy = path.join(root, 'setid-bwrap-copy');
+  fs.copyFileSync(infrastructureBinaries().bwrap, setidCopy);
+  fs.chmodSync(setidCopy, 0o4755);
+  assert.throws(() => trustedBinaryIdentity(setidCopy), /non-setid/,
+    'setuid and setgid helpers must fail closed before either path or copied execution');
+  if (typeof process.execve === 'function') {
+    const samePid = spawnSync(process.execPath, ['-e', `
+      const original = process.pid;
+      const next = 'process.stdout.write(String(process.pid === ' + original + '))';
+      process.execve(process.execPath, [process.execPath, '-e', next], {});
+    `], { encoding: 'utf8' });
+    assert.equal(samePid.status, 0);
+    assert.equal(samePid.stdout, 'true', 'execve must retain the validated sandbox process identity');
+
+    const nonzero = spawnSync(process.execPath, ['-e', `
+      process.execve(process.execPath, [process.execPath, '-e', 'process.exit(37)'], {});
+    `]);
+    assert.equal(nonzero.status, 37, 'an execve replacement must preserve a nonzero payload exit');
+
+    const signaled = spawn(process.execPath, ['-e', `
+      const next = 'process.stdout.write("ready:" + process.pid + "\\\\n"); setInterval(() => {}, 1000)';
+      process.execve(process.execPath, [process.execPath, '-e', next], {});
+    `], { stdio: ['ignore', 'pipe', 'inherit'] });
+    const [ready] = await once(signaled.stdout, 'data');
+    assert.equal(ready.toString().trim(), `ready:${signaled.pid}`,
+      'the execve replacement must retain the controller-visible PID');
+    signaled.kill('SIGTERM');
+    const [exitCode, signal] = await once(signaled, 'close');
+    assert.equal(exitCode, null);
+    assert.equal(signal, 'SIGTERM', 'signals must terminate the execve replacement directly');
+  }
+  const symlinkDiagnosticRoot = path.join(root, 'temporary-symlink-diagnostic');
+  fs.mkdirSync(symlinkDiagnosticRoot);
+  fs.symlinkSync('target', path.join(symlinkDiagnosticRoot, 'runtime-link'));
+  assert.deepEqual(boundedDirectorySize(symlinkDiagnosticRoot).symlink_paths,
+    ['runtime-link'], 'temporary symlink refusal must retain only bounded relative diagnostics');
   assert.equal(adapterProbe('darwin').production_enforcement, false);
   assert.equal(adapterProbe('win32').id, 'portable-process-group-small-only');
   assert.equal(

--- a/tests/safe_runner_test.mjs
+++ b/tests/safe_runner_test.mjs
@@ -47,7 +47,7 @@ import {
 import { commandOwnership, preflightRun, writableWorktreeProof } from '../scripts/safe-runner/preflight.mjs';
 import {
   existingLaminaProcesses, isLaminaProcessCommand, MAX_PROCESS_ENVIRONMENT_BYTES,
-  processEnvironmentAttestation,
+  processEnvironmentAttestation, processIdentity,
 } from '../scripts/safe-runner/processes.mjs';
 import {
   assertExecutionDependencyInodeBudget, assertExecutionSnapshot,
@@ -78,7 +78,8 @@ import {
 } from '../scripts/safe-runner/report.mjs';
 import {
   boundedDiagnosticText, closeOutputStreams, outcomeForStop, payloadRuntimeTimedOut, releaseFifo,
-  recordChildTermination, temporaryQuotaHandshakeFailure, waitForChildResult,
+  recordChildTermination, resolvePrivateManagedGraphdPaths, temporaryQuotaHandshakeFailure,
+  waitForChildResult,
 } from '../scripts/safe-runner/runner.mjs';
 import {
   bubblewrapSandboxArguments,
@@ -104,6 +105,7 @@ import {
   productionLockDirectory,
   promotionCommandDigest,
   repositorySourceDigest,
+  sealedManifestFileIdentity,
   writeAttestation,
 } from '../scripts/safe-runner/state.mjs';
 
@@ -121,6 +123,18 @@ function mountOperationIndex(args, option, source, target) {
 }
 
 try {
+  const sealedRuntimeInput = path.join(root, 'sealed-runtime-input');
+  fs.writeFileSync(sealedRuntimeInput, 'worker');
+  const sealedRuntimeDigest = crypto.createHash('sha256').update('worker').digest('hex');
+  assert.equal(sealedManifestFileIdentity(sealedRuntimeInput, {
+    bytes: 6, sha256: sealedRuntimeDigest,
+  }, 'worker').digest, sealedRuntimeDigest);
+  fs.writeFileSync(sealedRuntimeInput, 'mutate');
+  assert.throws(() => sealedManifestFileIdentity(sealedRuntimeInput, {
+    bytes: 6, sha256: sealedRuntimeDigest,
+  }, 'worker'), /failed sealed manifest identity/,
+  'same-size runtime input mutation must refuse before promotion identity can be reused');
+
   assert.equal(payloadRuntimeTimedOut(null, 60_000, 1_000), false,
     'controller preparation time must not consume the workload timeout');
   assert.equal(payloadRuntimeTimedOut(50_000, 50_999, 1_000), false);
@@ -621,6 +635,16 @@ try {
   assert.equal(commandOwnership([
     process.execPath, path.resolve('tests/fixtures/safe-runner-adversary.mjs'), 'success',
   ], root).network_access, 'isolated');
+  const runtimeBaselineEntrypoint = path.resolve('benchmarks/runtime-baseline-v1/workload.mjs');
+  for (const command of [
+    [process.execPath, runtimeBaselineEntrypoint],
+    [process.execPath, runtimeBaselineEntrypoint, 'run', '../small', 'footprint', 'a', 'b'],
+    [process.execPath, runtimeBaselineEntrypoint, 'run', 'small', '--scenario', 'a', 'b'],
+    [process.execPath, runtimeBaselineEntrypoint, 'run', 'small', 'footprint', 'a', 'b', 'extra'],
+  ]) {
+    assert.equal(commandOwnership(command, process.cwd()).proven, false,
+      'runtime baseline must refuse every non-exact fixture/scenario/input argv');
+  }
   const unsealedRetrievalRuntime = preflightRun({
     tier: 'small', cwd: process.cwd(), adapterInfo: portableProbe,
     command: [process.execPath, path.resolve('benchmarks/retrieval-v1/benchmark.mjs'), '--evaluate'],
@@ -1988,6 +2012,34 @@ try {
     environment: {},
   }), /invalid execution authority/,
   'graphd authority must reject a missing controller-sealed Git identity');
+  const baselineWorkerOverlay = path.join(
+    validGraphdSnapshot.snapshot_repository,
+    'packages/cli/observation-runtime/cocoindex-worker',
+  );
+  fs.mkdirSync(path.dirname(baselineWorkerOverlay), { recursive: true });
+  fs.writeFileSync(baselineWorkerOverlay, '#!/bin/sh\nexit 0\n', { mode: 0o500 });
+  const baselineSandboxAuthority = {
+    ...encodedGraphdAuthority,
+    audited_entrypoint: 'benchmarks/runtime-baseline-v1/workload.mjs',
+    writable_bindings: [],
+  };
+  assert.match(validateSandboxExecutionAuthority({
+    executionAuthority: baselineSandboxAuthority,
+    authorityRoot: validGraphdSnapshot.root,
+    cwd: snapshotRepository,
+    environment: {},
+  }).sealedGitIdentity, /^[A-Za-z0-9_-]+$/,
+  'runtime baseline must admit its sealed Git identity without a host writable binding');
+  assert.throws(() => validateSandboxExecutionAuthority({
+    executionAuthority: {
+      ...baselineSandboxAuthority,
+      writable_bindings: encodedGraphdAuthority.writable_bindings,
+    },
+    authorityRoot: validGraphdSnapshot.root,
+    cwd: snapshotRepository,
+    environment: {},
+  }), /invalid execution authority/,
+  'runtime baseline must never inherit the host Git-common scratch binding');
   const graphdSandboxArgs = bubblewrapSandboxArguments({
     cwd: snapshotRepository,
     readyFile: path.join(root, 'graphd.ready'),
@@ -2052,6 +2104,7 @@ try {
   const fixtureGraphdAuthority = validGraphdSnapshot.graphd_launch_authority[0];
   const fixtureGraphdChild = {
     argv: fixtureGraphdAuthority.argv,
+    cwd: fixtureGraphdAuthority.argv[2],
     executable_identity: fixtureGraphdAuthority.executable_identity,
     environment_attestation: processEnvironmentAttestation(
       Buffer.from('PATH=/usr/bin\0LAMINA_SAFE_GRAPHD_RESERVATION=sealed\0'),
@@ -2061,6 +2114,13 @@ try {
     socket: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.sock'),
     lock: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.lock'),
   }, validGraphdSnapshot.graphd_launch_authority), true);
+  assert.equal(exactGraphdLaunchAuthorized(fixtureGraphdChild, {
+    socket: '/proc/123/root/private/graphd.sock',
+    lock: '/proc/123/root/private/graphd.lock',
+    canonical_socket: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.sock'),
+    canonical_lock: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.lock'),
+  }, validGraphdSnapshot.graphd_launch_authority), true,
+  'namespace-private supervisor aliases must remain bound to canonical graphd authority');
   const gitHookGraphdChild = {
     ...fixtureGraphdChild,
     environment_attestation: processEnvironmentAttestation(Buffer.from(
@@ -2080,6 +2140,33 @@ try {
     lock: path.join(snapshotRepository, '.git', 'lamina', 'graphd.lock'),
   }, validGraphdSnapshot.graphd_launch_authority), false,
   'graphd-client fixture authority must remain bound to its nested scratch repository');
+  const privateManagedRoot = path.join(root, 'private-runtime-baseline');
+  const privateManagedRuntime = path.join(
+    privateManagedRoot, 'runs', 'small', 'footprint', 'sample-0', '.git', 'lamina',
+  );
+  fs.mkdirSync(privateManagedRuntime, { recursive: true });
+  const privateRequester = processIdentity(process.pid);
+  const privateLaunchAuthority = [{
+    kind: 'exact', private_tmp_root: privateManagedRoot,
+    runtime_directory: privateManagedRuntime,
+  }];
+  const privateResolved = resolvePrivateManagedGraphdPaths({
+    requester: privateRequester,
+    socket: path.join(privateManagedRuntime, 'graphd.sock'),
+    lock: path.join(privateManagedRuntime, 'graphd.lock'),
+    launchAuthority: privateLaunchAuthority,
+  });
+  assert.equal(privateResolved.socket,
+    `/proc/${process.pid}/root${path.join(privateManagedRuntime, 'graphd.sock')}`,
+  'private graphd socket authority must remain reachable only through requester namespace root');
+  assert.ok(reserveManagedObjects(privateResolved.socket, privateResolved.lock,
+    '1'.repeat(64)), 'namespace-private managed paths must retain exact parent identity');
+  assert.equal(resolvePrivateManagedGraphdPaths({
+    requester: privateRequester,
+    socket: path.join(privateManagedRoot, 'sibling', 'graphd.sock'),
+    lock: path.join(privateManagedRoot, 'sibling', 'graphd.lock'),
+    launchAuthority: privateLaunchAuthority,
+  }), null, 'private graphd authority must reject sibling runtime paths');
   const fixtureAlias = path.join(fixtureWork, 'alias');
   fs.symlinkSync(path.join(snapshotRepository, 'dist'), fixtureAlias);
   assert.throws(() => prepareExecutionSnapshot({

--- a/tests/safe_runner_test.mjs
+++ b/tests/safe_runner_test.mjs
@@ -2104,7 +2104,7 @@ try {
   const fixtureGraphdAuthority = validGraphdSnapshot.graphd_launch_authority[0];
   const fixtureGraphdChild = {
     argv: fixtureGraphdAuthority.argv,
-    cwd: fixtureGraphdAuthority.argv[2],
+    cwd: fixtureGraphdAuthority.cwd,
     executable_identity: fixtureGraphdAuthority.executable_identity,
     environment_attestation: processEnvironmentAttestation(
       Buffer.from('PATH=/usr/bin\0LAMINA_SAFE_GRAPHD_RESERVATION=sealed\0'),
@@ -2114,6 +2114,13 @@ try {
     socket: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.sock'),
     lock: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.lock'),
   }, validGraphdSnapshot.graphd_launch_authority), true);
+  assert.equal(exactGraphdLaunchAuthorized({
+    ...fixtureGraphdChild, cwd: fixtureGraphdAuthority.argv[2],
+  }, {
+    socket: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.sock'),
+    lock: path.join(fixtureGraphdAuthority.runtime_directory, 'graphd.lock'),
+  }, validGraphdSnapshot.graphd_launch_authority), false,
+  'exact graphd authority must reject a child launched from a different cwd');
   assert.equal(exactGraphdLaunchAuthorized(fixtureGraphdChild, {
     socket: '/proc/123/root/private/graphd.sock',
     lock: '/proc/123/root/private/graphd.lock',

--- a/tests/safe_runner_workflow_test.mjs
+++ b/tests/safe_runner_workflow_test.mjs
@@ -12,6 +12,8 @@ const packageManifest = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const adapter = fs.readFileSync('scripts/safe-runner/adapter.mjs', 'utf8');
 const systemd = fs.readFileSync('scripts/safe-runner/linux-systemd.mjs', 'utf8');
 const sandbox = fs.readFileSync('scripts/safe-runner/sandbox.mjs', 'utf8');
+const managedPaths = fs.readFileSync('scripts/safe-runner/managed-paths.mjs', 'utf8');
+const processes = fs.readFileSync('scripts/safe-runner/processes.mjs', 'utf8');
 const runner = fs.readFileSync('scripts/safe-runner/runner.mjs', 'utf8');
 const executionSnapshot = fs.readFileSync('scripts/safe-runner/execution-snapshot.mjs', 'utf8');
 const sealedGitProbe = fs.readFileSync(
@@ -104,6 +106,8 @@ assert.doesNotMatch(packageManifest.scripts['bench:retrieval'], /--worker|--mode
 
 assert.match(safeWorkflow, /LAMINA_SAFE_BWRAP_PATH=%s/);
 assert.match(safeWorkflow, /LAMINA_SAFE_BWRAP_SHA256=%s/);
+assert.match(safeWorkflow, /node-version:\s*'24'/,
+  'production adversarial CI must exercise the execve-capable sandbox launch path');
 assert.doesNotMatch(safeWorkflow, /echo "\$bin_dir" >> "\$GITHUB_PATH"/);
 assert.match(safeWorkflow,
   /Stage trusted private Node runtime[\s\S]*install -d -m 0700 "\$trust_root"[\s\S]*cp -a --no-preserve=ownership "\$source_root\/\." "\$trust_root\/"[\s\S]*chmod -R go-w "\$trust_root"/,
@@ -120,6 +124,20 @@ assert.equal(packageManifest.scripts['test:safe-runner:portable'],
 assert.match(adapter, /assertTrustedBinaryIdentity\(binaries\.identities\.bwrap\)[\s\S]*spawnSync\(binaries\.bwrap/);
 assert.match(systemd, /assertInfrastructureBinaries\(this\.infrastructure,[\s\S]*staged\.bwrap, bwrapIdentity/);
 assert.match(sandbox, /assertTrustedBinaryIdentity\(expectedBwrap\)[\s\S]*spawn\(bwrapExecutable/);
+assert.match(sandbox, /typeof process\.execve === 'function'[\s\S]*process\.execve\(bwrapExecutable/,
+  'execve-capable Node must replace the validated sandbox launcher with bwrap');
+assert.match(executionSnapshot,
+  /requiresSystemBwrapPath[\s\S]*trustedRootBinaryIdentity\(infrastructure\.bwrap[\s\S]*infrastructure:bwrap-system-path/,
+  'root-owned distribution bwrap must retain its path-based LSM identity and exact launch identity');
+assert.match(executionSnapshot,
+  /entry\.type === 'host-file'[\s\S]*source_nlink[\s\S]*execution snapshot host infrastructure identity changed/,
+  'external host infrastructure must revalidate its complete identity as snapshot authority');
+assert.match(managedPaths,
+  /namespacePrivate = physicalProcNamespaceDirectory\(parentPath\)[\s\S]*!namespacePrivate && fs\.realpathSync\.native\(parentPath\)/,
+  'namespace-private managed paths must be component-verified before any realpath dereference');
+assert.match(processes,
+  /readlinkSync\(`\/proc\/\$\{pid\}\/cwd`\)[\s\S]*path\.isAbsolute\(namespaceCwd\)[\s\S]*!namespaceCwd\.endsWith\('\s\(deleted\)'\)/,
+  'process cwd attestation must preserve the child mount-namespace path and reject deleted paths');
 assert.doesNotMatch(executionSnapshot, /EXPLICIT_ENTRYPOINT_WRITABLE_ROOTS/);
 assert.doesNotMatch(executionSnapshot,
   /prepare-retrieval-assets\.mjs[^\n]*index:\s*2/);


### PR DESCRIPTION
## Summary

- pin the small, medium, and polyglot large repository fixtures plus production retrieval assets
- run every baseline lifecycle through the sealed, quota-backed #59 safe runner
- preserve the root-owned distribution bwrap path only under full root ancestry, inode, digest, mode, link-count, and empty-file-capability attestation so Ubuntu path-based LSM authorization remains effective
- replace the idle sandbox Node wrapper with bwrap on execve-capable Node while retaining the Node 20 fallback
- remove the long-socket temporary symlink and use a tested parent-descriptor endpoint for native children
- record the current unoptimized small-tier baseline through its first enforced refusal

## Baseline outcome

This PR does not weaken the fixed safety envelope. It records the current runtime as it is:

| Scenario | Result |
| --- | --- |
| Footprint | Valid; 404,770,816-byte aggregate cgroup peak; 33-task peak; exact cleanup |
| Doctor/status plus graph startup | Valid cold samples: 459.175, 462.817, and 430.490 ms; median 459.175 ms; maximum 462.817 ms |
| Initial observation | Invalid safety-limited scenario; 64-task ceiling; pids.events.max=5; SIGTERM; zero descendants/managed paths; scope and temporary directory removed |
| Remaining small scenarios | Explicitly blocked after the preceding failure |
| Medium and large | Never dispatched because small promotion did not complete |

The failed initial-observation peaks are diagnostics, not performance measurements. Issue #60 explicitly requires a PID limit hit to remain a failed scenario and accepts schema-valid JSON or explicit safe refusal. The observed native/runtime thread demand is the evidence input for #51; the limit was not raised and the public CLI workload was not replaced with internal calls.

## Measurement identity

- Lamina measurement commit: `c087420266f7d6231c37fa9afc6c445b51bff48e`
- Fixture: `alan2207/bulletproof-react@9506629ed003a561c6627735480cce4994244bb4`
- Node: `v24.18.0`; glibc `2.43`; Linux x64 kernel `7.0.0-28-generic`
- Result index SHA-256: `658420c27ff3d6c85af7c439173cb6bdbf0756afc894b99bb6344360abe24801`
- Full raw report digests and reproduction commands: `benchmarks/runtime-baseline-v1/BASELINE.md`

## Safety evidence

The exact code passed:

- `LAMINA_SAFE_RUNNER_STATE_DIR=/tmp/lamina-issue60-final-safe-state npm run safe:self-test -- --require-production`
- all direct/aggregate memory, PID, timeout, output, temporary-disk, SIGINT, supervisor-SIGKILL, detached-descendant, and exact cleanup cases
- Node 24 same-PID exec replacement, exit-code, and SIGTERM behavior
- an authenticated child graph RPC over the long `/proc/<parent>/fd/<fd>` socket endpoint

Every production self-test case reported `cleanup_verified: true`.

## Focused verification

- `npm run test:runtime-baseline`
- `node tests/safe_runner_test.mjs`
- `node tests/safe_runner_workflow_test.mjs`
- `node tests/graphd_long_socket_test.mjs`
- `node tests/graphd_protocol_test.mjs`
- `node tests/cli_package_test.mjs`
- `git diff --check`

Two independent reviewers re-ran the focused suite and found no remaining merge blocker.

Closes #60
