### PR TITLE
feat(runtime): lifecycle, cancellation, cleanup, recovery (#70)

### DIFF
--- a/benchmarks/runtime-baseline-v1/workload.mjs
+++ b/benchmarks/runtime-baseline-v1/workload.mjs
@@ -16,6 +16,7 @@ import {
   applyRuntimeBudgetToEnvironment,
   runtimeBudgetFromEnvironment,
 } from '../../packages/cli/lib/runtime-budget.mjs';
+import { releaseGraphdBeforeObservation } from '../../packages/cli/lib/runtime-lifecycle.mjs';
 import { assertSafeRunnerContext } from '../../packages/cli/lib/safe-runner-context.mjs';
 import {
   assertScenario,
@@ -115,7 +116,7 @@ function childEnvironment(extra = {}) {
 
 async function releaseGraphdBeforeObservationCli(repository) {
   if (!runtimeBudgetFromEnvironment()) return;
-  await stopIncompatibleServer(runtimePaths(repository));
+  await releaseGraphdBeforeObservation(repository, { force: true });
 }
 
 function run(command, args, { cwd = REPOSITORY, env = childEnvironment(), input = null,
@@ -549,6 +550,7 @@ async function runSample({ fixture, manifest, source, scenario, index }) {
         fail('observation indexed count contradicts the pinned candidate set', { diagnostics, metadata });
       }
     } else if (scenario === 'initial-retrieval-readiness') {
+      await releaseGraphdBeforeObservationCli(repository);
       tracker.begin('observation');
       runTrackedCli(tracker, repository, ['graph', 'observe']);
       tracker.end();

--- a/packages/cli/lib/graph-runtime/client.mjs
+++ b/packages/cli/lib/graph-runtime/client.mjs
@@ -212,6 +212,38 @@ async function waitForServer(paths, token, child = null) {
   throw new Error(`graphd did not become ready at ${socketPath}`);
 }
 
+function removeGraphdRuntimeArtifacts(paths) {
+  const socketPath = graphSocketPath(paths);
+  for (const file of [paths.lock, socketPath]) {
+    try { if (fs.existsSync(file)) fs.unlinkSync(file); } catch {}
+  }
+}
+
+export async function recoverWedgedGraphd(paths, pid = null) {
+  let lock = null;
+  try { lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8')); } catch {}
+  const candidate = pid || lock?.pid || null;
+  if (!candidate) return false;
+  const socketPath = graphSocketPath(paths);
+  const socketMissing = process.platform !== 'win32' && !fs.existsSync(socketPath);
+  if (!processIsRunning(candidate)) {
+    removeGraphdRuntimeArtifacts(paths);
+    return true;
+  }
+  if (socketMissing) {
+    try { process.kill(candidate, 'SIGKILL'); } catch {}
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline && processIsRunning(candidate)) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    if (!processIsRunning(candidate)) {
+      removeGraphdRuntimeArtifacts(paths);
+      return true;
+    }
+  }
+  return false;
+}
+
 export async function stopIncompatibleServer(paths, reportedPid = null) {
   let lock = null;
   try { lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8')); } catch {}
@@ -227,7 +259,7 @@ export async function stopIncompatibleServer(paths, reportedPid = null) {
       }, 500);
     } catch {}
   }
-  let deadline = Date.now() + 2_000;
+  let deadline = Date.now() + 5_000;
   while (Date.now() < deadline && processIsRunning(pid)) {
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
@@ -246,6 +278,7 @@ export async function stopIncompatibleServer(paths, reportedPid = null) {
     }
   }
   if (processIsRunning(pid)) {
+    if (await recoverWedgedGraphd(paths, pid)) return;
     const error = new Error(`Unable to stop incompatible graphd process ${pid}.`);
     error.code = 'LAMINA_INTERNAL';
     throw error;
@@ -256,6 +289,7 @@ export async function ensureGraphd(cwd = process.cwd()) {
   const paths = runtimePaths(cwd);
   const socketPath = graphSocketPath(paths);
   const token = ensureAuthToken(paths);
+  await recoverWedgedGraphd(paths);
   let response = null;
   try {
     response = await exchange(socketPath, {
@@ -271,7 +305,28 @@ export async function ensureGraphd(cwd = process.cwd()) {
   let lock = null;
   try { lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8')); } catch {}
   if (response || processIsRunning(lock?.pid)) {
-    await stopIncompatibleServer(paths, response?.result?.pid);
+    const pid = response?.result?.pid || lock?.pid || null;
+    try {
+      await stopIncompatibleServer(paths, pid);
+    } catch (error) {
+      let revived = null;
+      try {
+        revived = await exchange(socketPath, {
+          id: 'revive-ping',
+          method: 'ping',
+          cwd,
+          auth: token,
+        }, 500);
+      } catch {}
+      if (revived?.ok && daemonCompatibility(revived.result).compatible) {
+        return { ...paths, auth_token: token, daemon: revived.result };
+      }
+      if (await recoverWedgedGraphd(paths, pid)) {
+        // Stale lock cleared; spawn a fresh graphd below.
+      } else {
+        throw error;
+      }
+    }
   }
   const debug = process.env.LAMINA_GRAPHD_DEBUG === '1';
   const logPath = path.join(paths.runtime_dir, 'graphd.log');

--- a/packages/cli/lib/graph-runtime/server.mjs
+++ b/packages/cli/lib/graph-runtime/server.mjs
@@ -241,16 +241,21 @@ function shutdown() {
     try { retrievalEmbedder.close(); } catch {}
     try { retrieval.close(); } catch {}
     try { engine.close(); } catch {}
-    if (process.platform !== 'win32') {
-      try { fs.unlinkSync(socketPath); } catch {}
-    }
-    try {
-      const lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8'));
-      if (lock?.pid === process.pid) fs.unlinkSync(paths.lock);
-    } catch {}
     process.exit(0);
   });
 }
+
+function removeRuntimeArtifacts() {
+  if (process.platform !== 'win32') {
+    try { fs.unlinkSync(socketPath); } catch {}
+  }
+  try {
+    const lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8'));
+    if (lock?.pid === process.pid) fs.unlinkSync(paths.lock);
+  } catch {}
+}
+
+process.on('exit', removeRuntimeArtifacts);
 
 process.on('SIGTERM', shutdown);
 process.on('SIGINT', shutdown);

--- a/packages/cli/lib/observation-runtime/cocoindex.mjs
+++ b/packages/cli/lib/observation-runtime/cocoindex.mjs
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { digest, graphSocketChildPath } from '../graph-runtime/util.mjs';
@@ -35,6 +35,63 @@ function unavailable(message, details = {}) {
   return error;
 }
 
+function observationFailure(status, signal, stderr, stdout) {
+  const error = new Error(`CocoIndex observation exited with status ${status ?? 1}.`);
+  error.code = 'LAMINA_OBSERVATION_FAILED';
+  error.details = {
+    backend: OBSERVATION_BACKEND,
+    status: status ?? 1,
+    signal: signal || null,
+    stderr: String(stderr || '').slice(-4_000),
+    stdout: String(stdout || '').slice(-4_000),
+  };
+  return error;
+}
+
+export function runLiveObservationProcess({ command, args, cwd, environment, cancellation }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    let stdout = '';
+    let settled = false;
+    const finish = (handler) => {
+      if (settled) return;
+      settled = true;
+      handler();
+    };
+    const stopChild = (signal = 'SIGTERM') => {
+      try { process.kill(-child.pid, signal); } catch {
+        try { child.kill(signal); } catch {}
+      }
+    };
+    const onCancel = () => {
+      stopChild('SIGTERM');
+    };
+    cancellation?.onCleanup?.(onCancel);
+    child.stdout.on('data', (chunk) => { stdout = `${stdout}${chunk}`.slice(-4_000); });
+    child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-4_000); });
+    child.on('error', (error) => finish(() => reject(unavailable(
+      'CocoIndex worker is unavailable. Reinstall this Lamina release to restore its private worker.',
+      { backend: OBSERVATION_BACKEND, cause: error.message },
+    ))));
+    child.on('exit', (status, signal) => finish(() => {
+      if (cancellation?.cancelled) {
+        const error = new Error('Observation was cancelled before completion.');
+        error.code = 'LAMINA_OBSERVATION_CANCELLED';
+        error.details = { backend: OBSERVATION_BACKEND, status, signal, stderr, stdout };
+        reject(error);
+        return;
+      }
+      if ((status ?? 1) !== 0) reject(observationFailure(status, signal, stderr, stdout));
+      else resolve({ status, stderr, stdout, cancelled: false });
+    }));
+  });
+}
+
 export function runObservationProcess({ command, args, cwd, environment }) {
   // CocoIndex can emit more than Node's 1 MiB spawnSync default while syncing
   // dependencies or reporting a large source scan. We retain only the final
@@ -48,10 +105,7 @@ export function runObservationProcess({ command, args, cwd, environment }) {
   });
   if (result.error) throw unavailable('CocoIndex worker is unavailable. Reinstall this Lamina release to restore its private worker.', { backend: OBSERVATION_BACKEND, cause: result.error.message });
   if ((result.status ?? 1) !== 0) {
-    const error = new Error(`CocoIndex observation exited with status ${result.status ?? 1}.`);
-    error.code = 'LAMINA_OBSERVATION_FAILED';
-    error.details = { backend: OBSERVATION_BACKEND, status: result.status ?? 1, signal: result.signal || null, stderr: String(result.stderr || '').slice(-4_000), stdout: String(result.stdout || '').slice(-4_000) };
-    throw error;
+    throw observationFailure(result.status, result.signal, result.stderr, result.stdout);
   }
   return {
     status: result.status,
@@ -61,7 +115,9 @@ export function runObservationProcess({ command, args, cwd, environment }) {
 }
 
 /** Run CocoIndex without exposing a Python/uv prerequisite to release users. */
-export function runCocoIndex({ paths, generation, live, ignore, extractorDigest }) {
+export async function runCocoIndex({
+  paths, generation, live, ignore, extractorDigest, cancellation = null,
+}) {
   const worker = managedWorker();
   const environment = {
     ...process.env,
@@ -98,6 +154,15 @@ export function runCocoIndex({ paths, generation, live, ignore, extractorDigest 
     if (live) args.push('--live');
     args.push('cocoindex_app.py');
     environment.UV_PROJECT_ENVIRONMENT = path.join(paths.cocoindex, 'python-env');
+  }
+  if (live) {
+    return runLiveObservationProcess({
+      command,
+      args,
+      cwd: packageRoot,
+      environment,
+      cancellation,
+    });
   }
   return runObservationProcess({
     command,

--- a/packages/cli/lib/observe.mjs
+++ b/packages/cli/lib/observe.mjs
@@ -14,7 +14,7 @@ import {
   maxObservationAttempts,
   runtimeBudgetFromEnvironment,
 } from './runtime-budget.mjs';
-import { releaseGraphdBeforeObservation } from './runtime-lifecycle.mjs';
+import { releaseGraphdBeforeObservation, runWithRuntimeLifecycle } from './runtime-lifecycle.mjs';
 
 const ignore = [
   '**/.git/**', '**/.lamina/runs/**', '**/.lamina/runtime/**', '**/.lamina/runtime-cli/**',
@@ -110,6 +110,7 @@ async function observationStatus(cwd, product, generation, timeout = 10_000) {
  * standalone release. The Node backend remains an explicit development switch.
  */
 export async function runObservation({ cwd = process.cwd(), live = false, invalidate = false, discover = false } = {}) {
+  return runWithRuntimeLifecycle(cwd, async ({ cancellation } = {}) => {
   const runtimeBudget = runtimeBudgetFromEnvironment();
   const backend = process.env.LAMINA_OBSERVATION_BACKEND || COCOINDEX_BACKEND;
   if (![COCOINDEX_BACKEND, NODE_BACKEND].includes(backend)) {
@@ -117,7 +118,7 @@ export async function runObservation({ cwd = process.cwd(), live = false, invali
     error.code = 'LAMINA_OBSERVATION_UNAVAILABLE';
     throw error;
   }
-  await releaseGraphdBeforeObservation(cwd);
+  await releaseGraphdBeforeObservation(cwd, { force: invalidate });
   const paths = await ensureGraphd(cwd);
   const invalidation = invalidate
     ? await graphRequest('observation.invalidate', { product: paths.product }, cwd)
@@ -129,7 +130,9 @@ export async function runObservation({ cwd = process.cwd(), live = false, invali
   const runWorker = async (attempt) => {
     try {
       if (backend === COCOINDEX_BACKEND) {
-        const result = runCocoIndex({ paths, generation, live, ignore, extractorDigest });
+        const result = await runCocoIndex({
+          paths, generation, live, ignore, extractorDigest, cancellation,
+        });
         workerDiagnostics.push({ attempt, ok: true, ...result });
       } else {
         await observeNode({
@@ -145,6 +148,7 @@ export async function runObservation({ cwd = process.cwd(), live = false, invali
       return true;
     } catch (error) {
       if (error.code === 'LAMINA_OBSERVATION_UNAVAILABLE') throw error;
+      if (error.code === 'LAMINA_OBSERVATION_CANCELLED') throw error;
       workerDiagnostics.push({
         attempt,
         ok: false,
@@ -272,4 +276,5 @@ export async function runObservation({ cwd = process.cwd(), live = false, invali
       limitations: observed.limitations,
     } : undefined,
   };
+  }, { live, mutation: true });
 }

--- a/packages/cli/lib/retrieval-runtime/process.mjs
+++ b/packages/cli/lib/retrieval-runtime/process.mjs
@@ -8,6 +8,11 @@ import { RETRIEVAL_SCHEMA_VERSION } from './constants.mjs';
 import { verifyRetrievalModel, verifyRetrievalRuntimeAssets } from './assets.mjs';
 import { retrievalIdentity, workflowDocuments } from './documents.mjs';
 import { workerThreadEnvironment } from '../runtime-budget.mjs';
+import {
+  assertCompatibleRuntimeIdentity,
+  releaseGraphdBeforeObservation,
+  runWithRuntimeLifecycle,
+} from '../runtime-lifecycle.mjs';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -134,6 +139,9 @@ export async function ensureRetrieval(
   cwd = process.cwd(),
   { force = false, allowLexicalDegraded = false } = {},
 ) {
+  return runWithRuntimeLifecycle(cwd, async () => {
+  assertCompatibleRuntimeIdentity(cwd);
+  await releaseGraphdBeforeObservation(cwd);
   let model;
   try {
     model = verifyRetrievalModel();
@@ -177,6 +185,7 @@ export async function ensureRetrieval(
     }
   }
   return { snapshot, status, model, graphd };
+  }, { mutation: true });
 }
 
 export async function queryRetrieval(query, prepared, cwd = process.cwd()) {

--- a/packages/cli/lib/retrieval-runtime/store.mjs
+++ b/packages/cli/lib/retrieval-runtime/store.mjs
@@ -243,6 +243,25 @@ export class RetrievalStore {
       this.connection.initSync();
       for (const statement of RETRIEVAL_SCHEMA) this.connection.querySync(statement);
     }
+    this.recoverInterruptedPendingGenerations();
+  }
+
+  recoverInterruptedPendingGenerations() {
+    const pending = this.query(
+      'MATCH (p:RetrievalPending) RETURN p.identity AS identity, p.generation AS generation',
+    );
+    if (!pending.length) return { recovered: 0 };
+    this.transaction(() => {
+      for (const row of pending) {
+        this.query(
+          'MATCH (m:RetrievalMember) WHERE m.identity = $identity AND m.generation = $generation DELETE m',
+          row,
+        );
+        this.query('MATCH (p:RetrievalPending {identity: $identity}) DELETE p', { identity: row.identity });
+      }
+    });
+    try { this.connection.querySync('CHECKPOINT'); } catch {}
+    return { recovered: pending.length };
   }
 
   close() {

--- a/packages/cli/lib/runtime-lifecycle.mjs
+++ b/packages/cli/lib/runtime-lifecycle.mjs
@@ -1,4 +1,4 @@
-/** Explicit graphd / worker lifecycle ownership for ADR-015 bounded topology (#69).
+/** Explicit graphd / worker lifecycle ownership for ADR-015 (#69 topology, #70 lifecycle).
  *
  * Single-writer durable store boundaries (canonical vs derived):
  * - graph.lbdb (canonical product graph): graphd only — GraphEngine in server.mjs
@@ -6,16 +6,322 @@
  * - cocoindex state.db (observation memoization): CocoIndex worker only; never Ladybug
  * - Observation batches: CocoIndex worker → graphd IPC only; never direct graph writes
  *
- * Lifecycle hooks coordinate descendant fan-out under ADR-014 pids.max without
- * raising safe-runner limits.
+ * Lifecycle state machine (bounded topology default-on):
+ * - cold: no graphd lock/socket for this repository
+ * - active: graphd serving IPC for the current CLI command
+ * - released: graphd stopped after a completed non-live mutation command
+ *
+ * Read-only commands (status, doctor, query) may keep graphd resident until the next
+ * mutation or explicit shutdown. Mutation commands release graphd on success so idle
+ * RSS and descendant counts return toward ADR-015 gates.
  */
 
-import { stopIncompatibleServer } from './graph-runtime/client.mjs';
-import { runtimePaths } from './graph-runtime/util.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import { GRAPH_PROTOCOL_VERSION } from './graph-runtime/constants.mjs';
+import { stopIncompatibleServer, daemonCompatibility, exchange, recoverWedgedGraphd } from './graph-runtime/client.mjs';
+import {
+  graphSocketPath,
+  parseDaemonLock,
+  processIsRunning,
+  runtimePaths,
+} from './graph-runtime/util.mjs';
+import { CLI_VERSION } from './runtime-identity.mjs';
 import { runtimeBudgetFromEnvironment } from './runtime-budget.mjs';
 
-/** Stop any inherited graphd tree before observation so seed + observe do not overlap. */
-export async function releaseGraphdBeforeObservation(cwd = process.cwd()) {
-  if (!runtimeBudgetFromEnvironment()) return;
-  await stopIncompatibleServer(runtimePaths(cwd));
+export const RUNTIME_IDENTITY_SCHEMA = 'lamina.runtime-identity/v1';
+const RUNTIME_IDENTITY_FILE = 'runtime-identity.json';
+const RUNTIME_ORPHAN_MARKERS = [
+  'cocoindex-worker',
+  'retrieval_worker.py',
+  'graph-runtime/server.mjs',
+  '--graphd',
+];
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function runtimeIdentityPath(cwd = process.cwd()) {
+  return path.join(runtimePaths(cwd).runtime_dir, RUNTIME_IDENTITY_FILE);
+}
+
+export function readRuntimeIdentity(cwd = process.cwd()) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(runtimeIdentityPath(cwd), 'utf8'));
+    if (parsed?.schema !== RUNTIME_IDENTITY_SCHEMA) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeRuntimeIdentity(cwd = process.cwd()) {
+  const paths = runtimePaths(cwd);
+  fs.mkdirSync(paths.runtime_dir, { recursive: true, mode: 0o700 });
+  const record = Object.freeze({
+    schema: RUNTIME_IDENTITY_SCHEMA,
+    cli_version: CLI_VERSION,
+    protocol_version: GRAPH_PROTOCOL_VERSION,
+    updated_at: new Date().toISOString(),
+  });
+  fs.writeFileSync(runtimeIdentityPath(cwd), stableJson(record), { mode: 0o600 });
+  return record;
+}
+
+export function assertCompatibleRuntimeIdentity(cwd = process.cwd()) {
+  const paths = runtimePaths(cwd);
+  if (!fs.existsSync(paths.database)) return { compatible: true, reason: 'greenfield' };
+  const identity = readRuntimeIdentity(cwd);
+  if (!identity) return { compatible: true, reason: 'legacy_unmarked' };
+  if (identity.cli_version !== CLI_VERSION || identity.protocol_version !== GRAPH_PROTOCOL_VERSION) {
+    const error = new Error(
+      'The installed Lamina CLI is incompatible with the existing runtime identity. '
+      + 'Back up the canonical graph, then reset derived stores or migrate before mutation.',
+    );
+    error.code = 'LAMINA_RUNTIME_INCOMPATIBLE';
+    error.details = {
+      database: paths.database,
+      identity,
+      expected: { cli_version: CLI_VERSION, protocol_version: GRAPH_PROTOCOL_VERSION },
+      remediation: ['backup', 'export', 'reset-derived', 'migrate'],
+    };
+    throw error;
+  }
+  return { compatible: true, identity };
+}
+
+/** Stop inherited graphd before observation when overlap would exhaust the task budget. */
+export async function releaseGraphdBeforeObservation(cwd = process.cwd(), { force = false } = {}) {
+  if (!runtimeBudgetFromEnvironment()) return { released: false, reason: 'unbounded' };
+  const paths = runtimePaths(cwd);
+  let lock = null;
+  try { lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8')); } catch {}
+  if (!processIsRunning(lock?.pid)) return { released: false, reason: 'absent' };
+  if (!force) {
+    try {
+      const token = fs.readFileSync(paths.token, 'utf8').trim();
+      const response = await exchange(graphSocketPath(paths), {
+        id: 'pre-observation-ping',
+        method: 'ping',
+        cwd,
+        auth: token,
+      }, 500);
+      if (response?.ok && daemonCompatibility(response.result).compatible) {
+        return { released: false, reason: 'compatible_daemon' };
+      }
+    } catch {}
+    if (await recoverWedgedGraphd(paths, lock?.pid)) {
+      return { released: false, reason: 'recovered_wedge' };
+    }
+  }
+  try {
+    await stopIncompatibleServer(paths, lock?.pid);
+    return { released: true, reason: force ? 'pre_observation_forced' : 'pre_observation' };
+  } catch (error) {
+    return {
+      released: false,
+      reason: 'stop_failed',
+      error: { code: error.code || 'LAMINA_INTERNAL', message: error.message },
+    };
+  }
+}
+
+export function shouldReleaseGraphdAfterCommand({
+  persistGraphd = false,
+  budget = runtimeBudgetFromEnvironment(),
+} = {}) {
+  if (process.env.LAMINA_RUNTIME_PERSIST_GRAPHD === '1') return false;
+  if (!budget || persistGraphd) return false;
+  return true;
+}
+
+/** Release graphd after a completed mutation command under bounded topology. */
+export async function releaseGraphdAfterCommand(cwd = process.cwd(), options = {}) {
+  if (!shouldReleaseGraphdAfterCommand(options)) {
+    return { released: false, reason: options.persistGraphd ? 'persist_graphd' : 'unbounded' };
+  }
+  const paths = runtimePaths(cwd);
+  try {
+    await stopIncompatibleServer(paths);
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline && fs.existsSync(paths.lock)) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return { released: true, reason: 'post_command' };
+  } catch (error) {
+    let lock = null;
+    try { lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8')); } catch {}
+    if (!processIsRunning(lock?.pid)) {
+      for (const file of [paths.lock, graphSocketPath(paths)]) {
+        try { if (fs.existsSync(file)) fs.unlinkSync(file); } catch {}
+      }
+      return { released: true, reason: 'stale_lock_recovered' };
+    }
+    return {
+      released: false,
+      reason: 'stop_failed',
+      error: { code: error.code || 'LAMINA_INTERNAL', message: error.message },
+    };
+  }
+}
+
+function readProcessCommand(pid) {
+  try {
+    return fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' ').trim();
+  } catch {
+    return '';
+  }
+}
+
+function readProcessPpid(pid) {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const close = stat.lastIndexOf(')');
+    return Number(stat.slice(close + 2).trim().split(/\s+/)[1] || 0);
+  } catch {
+    return 0;
+  }
+}
+
+/** Enumerate likely Lamina runtime descendants for orphan checks (Linux only). */
+export function listRuntimeDescendantPids(cwd = process.cwd(), { exceptPid = process.pid } = {}) {
+  if (process.platform !== 'linux' || !fs.existsSync('/proc')) return [];
+  const paths = runtimePaths(cwd);
+  let graphdPid = null;
+  try {
+    const lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8'));
+    if (processIsRunning(lock?.pid)) graphdPid = lock.pid;
+  } catch {}
+  const root = path.resolve(paths.root);
+  const matches = [];
+  for (const entry of fs.readdirSync('/proc')) {
+    const pid = Number(entry);
+    if (!Number.isInteger(pid) || pid <= 1 || pid === exceptPid) continue;
+    const command = readProcessCommand(pid);
+    if (!command) continue;
+    const markerHit = RUNTIME_ORPHAN_MARKERS.some((marker) => command.includes(marker));
+    const cwdLink = (() => {
+      try { return fs.readlinkSync(`/proc/${pid}/cwd`); } catch { return ''; }
+    })();
+    const inRepo = cwdLink && (cwdLink === root || cwdLink.startsWith(`${root}${path.sep}`));
+    const childOfGraphd = graphdPid && readProcessPpid(pid) === graphdPid;
+    if (markerHit && (inRepo || childOfGraphd)) matches.push(pid);
+  }
+  return [...new Set(matches)].sort((left, right) => left - right);
+}
+
+export async function assertNoRuntimeOrphans(cwd = process.cwd(), options = {}) {
+  const remaining = listRuntimeDescendantPids(cwd, options)
+    .filter((pid) => processIsRunning(pid));
+  if (!remaining.length) return { ok: true, remaining: [] };
+  const error = new Error('Lamina runtime descendants remain after command cleanup.');
+  error.code = 'LAMINA_RUNTIME_ORPHAN';
+  error.details = {
+    remaining: remaining.map((pid) => ({ pid, command: readProcessCommand(pid) })),
+  };
+  throw error;
+}
+
+export async function forceStopRuntimeOrphans(cwd = process.cwd(), options = {}) {
+  const paths = runtimePaths(cwd);
+  let graphdPid = null;
+  try {
+    const lock = parseDaemonLock(fs.readFileSync(paths.lock, 'utf8'));
+    if (processIsRunning(lock?.pid)) graphdPid = lock.pid;
+  } catch {}
+  const pids = listRuntimeDescendantPids(cwd, options)
+    .filter((pid) => processIsRunning(pid) && pid !== graphdPid);
+  for (const pid of pids) {
+    try { process.kill(pid, 'SIGTERM'); } catch {}
+  }
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (!pids.some((pid) => processIsRunning(pid))) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  for (const pid of pids) {
+    if (processIsRunning(pid)) {
+      try { process.kill(pid, 'SIGKILL'); } catch {}
+    }
+  }
+  return { stopped: pids };
+}
+
+let activeCancellation = null;
+
+export function installCommandCancellation({ onCancel, label = 'command' } = {}) {
+  if (activeCancellation) return activeCancellation;
+  let cancelled = false;
+  const cleanups = [];
+  const handler = (signal) => {
+    if (cancelled) return;
+    cancelled = true;
+    for (const cleanup of cleanups.splice(0)) {
+      try { cleanup(signal); } catch {}
+    }
+    try { onCancel?.(signal); } catch {}
+  };
+  process.once('SIGINT', handler);
+  process.once('SIGTERM', handler);
+  activeCancellation = {
+    label,
+    onCleanup(fn) {
+      if (typeof fn === 'function') cleanups.push(fn);
+      return this;
+    },
+    cancel: () => handler('SIGINT'),
+    dispose() {
+      process.removeListener('SIGINT', handler);
+      process.removeListener('SIGTERM', handler);
+      if (activeCancellation === this) activeCancellation = null;
+    },
+    get cancelled() { return cancelled; },
+  };
+  return activeCancellation;
+}
+
+export function disposeCommandCancellation(token) {
+  token?.dispose?.();
+}
+
+export async function finalizeRuntimeCommand(cwd, {
+  persistGraphd = false,
+  cleanupOrphans = true,
+} = {}) {
+  const results = {};
+  results.graphd = await releaseGraphdAfterCommand(cwd, { persistGraphd });
+  if (cleanupOrphans && process.platform === 'linux') {
+    results.orphans = await forceStopRuntimeOrphans(cwd);
+  }
+  if (cleanupOrphans && process.platform === 'linux') {
+    results.orphan_check = await assertNoRuntimeOrphans(cwd).catch((error) => ({
+      ok: false,
+      error: { code: error.code, message: error.message, details: error.details || {} },
+    }));
+  }
+  return results;
+}
+
+export async function runWithRuntimeLifecycle(cwd, fn, {
+  live = false,
+  persistGraphd = false,
+  mutation = false,
+} = {}) {
+  if (mutation) assertCompatibleRuntimeIdentity(cwd);
+  let cancellation = null;
+  if (live) {
+    cancellation = installCommandCancellation({
+      label: 'live_runtime',
+      onCancel: () => {},
+    });
+  }
+  try {
+    const result = await fn({ cancellation });
+    if (mutation && !live) writeRuntimeIdentity(cwd);
+    return result;
+  } finally {
+    disposeCommandCancellation(cancellation);
+    await finalizeRuntimeCommand(cwd, { persistGraphd });
+  }
 }

--- a/tests/observation_cli_test.mjs
+++ b/tests/observation_cli_test.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
+// This suite keeps a warm graphd across sequential CLI invocations via graphRequest.
+process.env.LAMINA_RUNTIME_PERSIST_GRAPHD = '1';
 import {
   graphRequest,
   stopIncompatibleServer,

--- a/tests/runtime_budget_test.mjs
+++ b/tests/runtime_budget_test.mjs
@@ -10,6 +10,7 @@ import {
   threadLimitEnvironment,
   workerThreadEnvironment,
 } from '../packages/cli/lib/runtime-budget.mjs';
+import { shouldReleaseGraphdAfterCommand } from '../packages/cli/lib/runtime-lifecycle.mjs';
 
 assert.equal(runtimeBudgetFromEnvironment({ LAMINA_RUNTIME_BOUNDED_TOPOLOGY: '0' }), null);
 assert.equal(runtimeBudgetFromEnvironment({ LAMINA_RUNTIME_BOUNDED_TOPOLOGY: 'false' }), null);
@@ -21,6 +22,7 @@ assert.equal(defaultBudget.worker_threads, 1);
 assert.equal(defaultBudget.observation_workers_max, 1);
 assert.equal(defaultBudget.observation_retries_max, 0);
 assert.equal(defaultBudget.defer_graphd_compat_recovery, true);
+assert.equal(defaultBudget.idle_graphd_shutdown_ms, 0);
 
 const explicitBudget = runtimeBudgetFromEnvironment({ LAMINA_RUNTIME_BOUNDED_TOPOLOGY: '1' });
 assert.ok(explicitBudget);
@@ -77,5 +79,7 @@ const applied = applyRuntimeBudgetToEnvironment({ HOME: '/tmp' }, defaultBudget)
 assert.equal(applied.HOME, '/tmp');
 assert.equal(applied.LAMINA_RUNTIME_BOUNDED_TOPOLOGY, '1');
 assert.equal(applied.LAMINA_RUNTIME_GRAPHD_THREADS, '1');
+assert.equal(shouldReleaseGraphdAfterCommand({ persistGraphd: false, budget: defaultBudget }), true);
+assert.equal(shouldReleaseGraphdAfterCommand({ persistGraphd: true, budget: defaultBudget }), false);
 
 process.stdout.write('runtime budget tests passed\n');

--- a/tests/runtime_lifecycle_test.mjs
+++ b/tests/runtime_lifecycle_test.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  RUNTIME_IDENTITY_SCHEMA,
+  assertCompatibleRuntimeIdentity,
+  readRuntimeIdentity,
+  releaseGraphdAfterCommand,
+  shouldReleaseGraphdAfterCommand,
+  writeRuntimeIdentity,
+} from '../packages/cli/lib/runtime-lifecycle.mjs';
+import { runtimePaths } from '../packages/cli/lib/graph-runtime/util.mjs';
+import { GRAPH_PROTOCOL_VERSION } from '../packages/cli/lib/graph-runtime/constants.mjs';
+import { CLI_VERSION } from '../packages/cli/lib/runtime-identity.mjs';
+import { removeTemporaryTree } from './test-util.mjs';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lamina-runtime-lifecycle-'));
+execFileSync('git', ['init', '-b', 'main'], { cwd: root });
+execFileSync('git', ['config', 'user.email', 'test@lamina.invalid'], { cwd: root });
+execFileSync('git', ['config', 'user.name', 'Lamina Test'], { cwd: root });
+fs.writeFileSync(path.join(root, 'README.md'), '# lifecycle\n');
+execFileSync('git', ['add', 'README.md'], { cwd: root });
+execFileSync('git', ['commit', '-m', 'fixture'], { cwd: root });
+const paths = runtimePaths(root);
+fs.mkdirSync(paths.runtime_dir, { recursive: true, mode: 0o700 });
+
+assert.equal(assertCompatibleRuntimeIdentity(root).reason, 'greenfield');
+fs.writeFileSync(paths.database, 'stub\n', { mode: 0o600 });
+assert.equal(assertCompatibleRuntimeIdentity(root).reason, 'legacy_unmarked');
+
+const identity = writeRuntimeIdentity(root);
+assert.equal(identity.schema, RUNTIME_IDENTITY_SCHEMA);
+assert.equal(identity.cli_version, CLI_VERSION);
+assert.equal(identity.protocol_version, GRAPH_PROTOCOL_VERSION);
+assert.deepEqual(readRuntimeIdentity(root), identity);
+assert.equal(assertCompatibleRuntimeIdentity(root).compatible, true);
+
+const previous = process.env.LAMINA_RUNTIME_BOUNDED_TOPOLOGY;
+process.env.LAMINA_RUNTIME_BOUNDED_TOPOLOGY = '1';
+assert.equal(shouldReleaseGraphdAfterCommand({ persistGraphd: false }), true);
+assert.equal(shouldReleaseGraphdAfterCommand({ persistGraphd: true }), false);
+process.env.LAMINA_RUNTIME_BOUNDED_TOPOLOGY = '0';
+assert.equal(shouldReleaseGraphdAfterCommand({ persistGraphd: false }), false);
+if (previous === undefined) delete process.env.LAMINA_RUNTIME_BOUNDED_TOPOLOGY;
+else process.env.LAMINA_RUNTIME_BOUNDED_TOPOLOGY = previous;
+
+const incompatible = {
+  schema: RUNTIME_IDENTITY_SCHEMA,
+  cli_version: '0.0.1',
+  protocol_version: GRAPH_PROTOCOL_VERSION,
+};
+fs.writeFileSync(runtimePaths(root).runtime_dir + '/runtime-identity.json', `${JSON.stringify(incompatible)}\n`);
+assert.throws(
+  () => assertCompatibleRuntimeIdentity(root),
+  (error) => error.code === 'LAMINA_RUNTIME_INCOMPATIBLE',
+);
+
+const released = await releaseGraphdAfterCommand(root, { persistGraphd: false });
+assert.equal(released.released, true);
+assert.equal(released.reason, 'post_command');
+
+const kept = await releaseGraphdAfterCommand(root, { persistGraphd: true });
+assert.equal(kept.released, false);
+assert.equal(kept.reason, 'persist_graphd');
+
+removeTemporaryTree(root);
+process.stdout.write('runtime lifecycle tests passed\n');


### PR DESCRIPTION
## Summary
- Extend `runtime-lifecycle.mjs` with post-command graphd release, runtime identity markers, orphan cleanup, live CocoIndex cancellation, and `runWithRuntimeLifecycle` wiring for observe/retrieval paths
- Recover interrupted retrieval pending generations on graphd open; recover wedged graphd lock/socket states after shutdown races
- Fix `initial-retrieval-readiness` baseline overlap via forced graphd release before observation (same as `initial-observation`)

## Test plan
- [x] `npm run test:real-repository-oracle`
- [x] `npm run test:runtime-baseline`
- [x] `node tests/runtime_budget_test.mjs`
- [x] `node tests/runtime_lifecycle_test.mjs`
- [x] `node tests/observation_cli_test.mjs`
- [x] `node tests/graphd_protocol_test.mjs`

Builds on #79 / `perf/issue-69-topology` (ADR-015 topology leaf).


Made with [Cursor](https://cursor.com)