### PR TITLE
feat(cli): observation and retrieval generation sync (#71–#73)

### DIFF
--- a/packages/cli/lib/observation-generation.mjs
+++ b/packages/cli/lib/observation-generation.mjs
@@ -1,0 +1,246 @@
+/** Observation generation, invalidation, tombstones, and interrupted recovery (#72).
+ *
+ * Derived observation state only — never writes canonical product truth.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { sha256 as contractSha256 } from '../../../benchmarks/runtime-baseline-v1/contract.mjs';
+import { canonical, digest, repositoryContext } from './graph-runtime/util.mjs';
+import { enumerateObservationPaths, gitByteCompare } from './source-inventory.mjs';
+
+export const OBSERVATION_GENERATION_SCHEMA = 'lamina.observation-generation/v1';
+export const GENERATION_STATE_FILE = 'observation-generation-state.json';
+
+export function observationFreshnessContext(cwd = process.cwd()) {
+  const repository = repositoryContext(cwd);
+  return Object.freeze({
+    source_revision: repository.source_revision,
+    repository_revision: repository.revision || '',
+    branch: repository.branch,
+    worktree: repository.root,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function observationMembershipDigest(records) {
+  const entries = Object.entries(records || {})
+    .sort(([left], [right]) => gitByteCompare(left, right))
+    .map(([sourceKey, record]) => `${sourceKey}\0${record?.fingerprint || ''}\0${record?.id || ''}`);
+  return contractSha256(entries.join('\n'));
+}
+
+export function generationStatePath(cocoindexDir) {
+  return path.join(cocoindexDir, GENERATION_STATE_FILE);
+}
+
+export function emptyGenerationState() {
+  return {
+    schema: OBSERVATION_GENERATION_SCHEMA,
+    version: 1,
+    generation: null,
+    source_revision: null,
+    repository_revision: '',
+    branch: null,
+    worktree: null,
+    records: {},
+    tombstones: {},
+    membership_digest: contractSha256(''),
+    commit_phase: 'committed',
+    non_canonical: true,
+    writes_product_truth: false,
+  };
+}
+
+export function readGenerationState(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    if (parsed?.schema !== OBSERVATION_GENERATION_SCHEMA) return emptyGenerationState();
+    return {
+      ...emptyGenerationState(),
+      ...parsed,
+      records: parsed.records || {},
+      tombstones: parsed.tombstones || {},
+    };
+  } catch {
+    return emptyGenerationState();
+  }
+}
+
+export function writeGenerationState(statePath, state) {
+  const normalized = Object.freeze({
+    ...state,
+    schema: OBSERVATION_GENERATION_SCHEMA,
+    version: 1,
+    membership_digest: observationMembershipDigest(state.records),
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+  fs.writeFileSync(statePath, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });
+  return normalized;
+}
+
+export function freshnessChanged(previous, current) {
+  return !previous
+    || previous.source_revision !== current.source_revision
+    || previous.repository_revision !== current.repository_revision
+    || previous.branch !== current.branch
+    || previous.worktree !== current.worktree;
+}
+
+export function interruptedRecoveryNeeded(previous, { generation, freshness }) {
+  if (!previous || previous.generation !== generation) return false;
+  if (previous.commit_phase !== 'pending') return false;
+  return !freshnessChanged(previous, freshness);
+}
+
+export function buildObservationEnvelope({
+  relative,
+  content,
+  snapshot,
+  extractSignals,
+  extractor = { id: 'lamina.source-file', version: '2' },
+}) {
+  const contentHash = crypto.createHash('sha256').update(content).digest('hex');
+  const payload = {
+    media_type: content.subarray(0, 4096).includes(0) ? 'binary' : 'text',
+    byte_length: content.length,
+    brownfield: extractSignals(relative, content),
+  };
+  const envelope = {
+    source_snapshot: snapshot,
+    source_key: relative,
+    content_hash: contentHash,
+    path: relative,
+    extractor,
+    payload,
+  };
+  envelope.id = digest('observation', {
+    snapshot: envelope.source_snapshot,
+    source_key: envelope.source_key,
+    content_hash: envelope.content_hash,
+    extractor: envelope.extractor,
+    payload: envelope.payload,
+  });
+  const fingerprint = digest('fingerprint', canonical(envelope));
+  return { envelope, fingerprint };
+}
+
+export function planObservationSync({
+  repositoryRoot,
+  generation,
+  snapshot,
+  freshness,
+  previous,
+  extractSignals,
+  readFile = fs.readFileSync,
+}) {
+  const nextRecords = {};
+  const envelopes = [];
+  const fullReconcile = previous.generation !== generation || freshnessChanged(previous, freshness);
+  const interrupted = interruptedRecoveryNeeded(previous, { generation, freshness });
+
+  for (const { path: relative } of enumerateObservationPaths(repositoryRoot)) {
+    let content;
+    try { content = readFile(path.join(repositoryRoot, relative)); } catch { continue; }
+    const { envelope, fingerprint } = buildObservationEnvelope({
+      relative,
+      content,
+      snapshot,
+      extractSignals,
+    });
+    nextRecords[relative] = { id: envelope.id, fingerprint };
+    if (fullReconcile || interrupted || previous.records[relative]?.fingerprint !== fingerprint) {
+      envelopes.push(envelope);
+    }
+  }
+
+  const tombstones = { ...previous.tombstones };
+  const deletes = [];
+  for (const [relative, record] of Object.entries(previous.records)) {
+    if (nextRecords[relative]) continue;
+    deletes.push(record.id);
+    tombstones[relative] = Object.freeze({
+      id: record.id,
+      generation,
+      tombstoned_at: new Date().toISOString(),
+      reason: 'path_removed',
+    });
+  }
+
+  const membershipDigest = observationMembershipDigest(nextRecords);
+  return Object.freeze({
+    generation,
+    snapshot,
+    freshness,
+    envelopes,
+    deletes,
+    tombstones,
+    records: nextRecords,
+    membership_digest: membershipDigest,
+    expected_count: Object.keys(nextRecords).length,
+    full_reconcile: fullReconcile,
+    interrupted_recovery: interrupted,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function activateGenerationPlan(plan, observedStatus = null) {
+  if (!plan || typeof plan !== 'object') {
+    throw new Error('observation generation activation requires a plan');
+  }
+  const actualDigest = observationMembershipDigest(plan.records);
+  if (actualDigest !== plan.membership_digest) {
+    const error = new Error('Observation generation membership digest is invalid; it was not activated.');
+    error.code = 'LAMINA_OBSERVATION_INCOMPLETE';
+    error.details = {
+      expected_digest: plan.membership_digest,
+      actual_digest: actualDigest,
+      non_canonical: true,
+    };
+    throw error;
+  }
+  if (observedStatus?.exists) {
+    const observedCount = Number(observedStatus.source_key_count ?? observedStatus.count ?? 0);
+    if (observedCount !== plan.expected_count) {
+      const error = new Error('Observation generation item count is incomplete; it was not activated.');
+      error.code = 'LAMINA_OBSERVATION_INCOMPLETE';
+      error.details = {
+        expected_count: plan.expected_count,
+        observed_count: observedCount,
+        membership_digest: plan.membership_digest,
+        non_canonical: true,
+      };
+      throw error;
+    }
+  }
+  return Object.freeze({
+    generation: plan.generation,
+    membership_digest: plan.membership_digest,
+    expected_count: plan.expected_count,
+    committed: true,
+    interrupted_recovery: plan.interrupted_recovery,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function commitGenerationState(statePath, plan, { phase = 'committed' } = {}) {
+  return writeGenerationState(statePath, {
+    schema: OBSERVATION_GENERATION_SCHEMA,
+    version: 1,
+    generation: plan.generation,
+    source_revision: plan.freshness.source_revision,
+    repository_revision: plan.freshness.repository_revision,
+    branch: plan.freshness.branch,
+    worktree: plan.freshness.worktree,
+    records: plan.records,
+    tombstones: plan.tombstones,
+    membership_digest: plan.membership_digest,
+    commit_phase: phase,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}

--- a/packages/cli/lib/observation-runtime/node.mjs
+++ b/packages/cli/lib/observation-runtime/node.mjs
@@ -1,14 +1,18 @@
 /* Self-contained source observation backend.  It deliberately talks only to
  * graphd: this module must never open the canonical Ladybug database. */
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { digest, canonical, runtimePaths } from '../graph-runtime/util.mjs';
+import { runtimePaths } from '../graph-runtime/util.mjs';
+import {
+  activateGenerationPlan,
+  commitGenerationState,
+  generationStatePath,
+  observationFreshnessContext,
+  planObservationSync,
+  readGenerationState,
+} from '../observation-generation.mjs';
 
 export const OBSERVATION_BACKEND = 'node';
-
-const ignoredNames = new Set(['.git', 'node_modules', '__pycache__', '.next', 'dist', 'build', 'coverage']);
-const ignoredSuffixes = ['.venv'];
 
 function unique(values, limit = 100) {
   return [...new Set(values.map((value) => String(value).trim()).filter(Boolean))].sort().slice(0, limit);
@@ -47,56 +51,52 @@ export function brownfieldSignals(relativePath, content) {
   return { categories: Object.keys(normalized).filter((key) => normalized[key].length).sort(), signals: Object.fromEntries(Object.entries(normalized).filter(([, values]) => values.length)), unsupported: truncated ? ['static_scan_truncated'] : [] };
 }
 
-function isIgnored(relative, entry) {
-  const pieces = relative.split('/');
-  if (pieces.includes('.git') || (pieces[0] === '.lamina' && pieces[1] === 'runs')) return true;
-  if (
-    (pieces[0] === '.lamina' && ['runtime', 'runtime-cli'].includes(pieces[1])) ||
-    (['.agents', '.codex', '.claude', '.opencode'].includes(pieces[0]) && pieces[1] === 'skills')
-  ) return true;
-  return pieces.some((part) => ignoredNames.has(part) || ignoredSuffixes.some((suffix) => part.startsWith(suffix)) || /^\.venv/.test(part)) || relative.startsWith('benchmarks/results/') || relative.includes('/.vendor-tmp');
-}
-
-function files(root, directory = root, output = []) {
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    const full = path.join(directory, entry.name);
-    const relative = path.relative(root, full).split(path.sep).join('/');
-    if (isIgnored(relative, entry)) continue;
-    if (entry.isDirectory()) files(root, full, output);
-    else if (entry.isFile()) output.push(relative);
-  }
-  return output.sort();
-}
-
-function readState(statePath) {
-  try { return JSON.parse(fs.readFileSync(statePath, 'utf8')); } catch { return { version: 1, generation: null, source_revision: null, records: {} }; }
-}
-
-export async function observeNode({ paths, generation, graphRequest, live = false, ignoreDigest, extractorDigest }) {
-  const statePath = path.join(paths.cocoindex, 'node-observation-state.json');
+export async function observeNode({
+  paths,
+  generation,
+  graphRequest,
+  live = false,
+  ignoreDigest,
+  extractorDigest,
+}) {
+  const statePath = generationStatePath(paths.cocoindex);
   const once = async () => {
     // A live observer must take a fresh Git/source snapshot for each pass;
     // otherwise updates would retain stale source revisions indefinitely.
     const current = runtimePaths(paths.root);
-    const snapshot = { product: current.product, source_revision: current.source_revision, source_root: current.root, ignore_policy_digest: ignoreDigest, extractor_set_digest: extractorDigest };
-    const previous = readState(statePath);
-    const next = {};
-    const envelopes = [];
-    const fullReconcile = previous.generation !== generation || previous.source_revision !== current.source_revision;
-    for (const relative of files(current.root)) {
-      let content; try { content = fs.readFileSync(path.join(current.root, relative)); } catch { continue; }
-      const contentHash = crypto.createHash('sha256').update(content).digest('hex');
-      const payload = { media_type: content.subarray(0, 4096).includes(0) ? 'binary' : 'text', byte_length: content.length, brownfield: brownfieldSignals(relative, content) };
-      const extractor = { id: 'lamina.source-file', version: '2' };
-      const envelope = { source_snapshot: snapshot, source_key: relative, content_hash: contentHash, path: relative, extractor, payload };
-      envelope.id = digest('observation', { snapshot: envelope.source_snapshot, source_key: envelope.source_key, content_hash: envelope.content_hash, extractor: envelope.extractor, payload: envelope.payload });
-      next[relative] = { id: envelope.id, fingerprint: digest('fingerprint', canonical(envelope)) };
-      if (fullReconcile || previous.records[relative]?.fingerprint !== next[relative].fingerprint) envelopes.push(envelope);
+    const freshness = observationFreshnessContext(current.root);
+    const snapshot = {
+      product: current.product,
+      source_revision: freshness.source_revision,
+      source_root: current.root,
+      ignore_policy_digest: ignoreDigest,
+      extractor_set_digest: extractorDigest,
+    };
+    const previous = readGenerationState(statePath);
+    const plan = planObservationSync({
+      repositoryRoot: current.root,
+      generation,
+      snapshot,
+      freshness,
+      previous,
+      extractSignals: brownfieldSignals,
+    });
+    if (plan.envelopes.length || plan.deletes.length || plan.full_reconcile) {
+      commitGenerationState(statePath, plan, { phase: 'pending' });
+      await graphRequest('observation.apply', {
+        snapshot,
+        generation,
+        upserts: plan.envelopes,
+        deletes: plan.deletes,
+      }, current.root);
     }
-    const deletes = Object.entries(previous.records).filter(([relative]) => !next[relative]).map(([, record]) => record.id);
-    if (envelopes.length || deletes.length || fullReconcile) await graphRequest('observation.apply', { snapshot, generation, upserts: envelopes, deletes }, current.root);
-    fs.writeFileSync(statePath, `${JSON.stringify({ version: 1, generation, source_revision: current.source_revision, records: next })}\n`, { mode: 0o600 });
-    if (process.env.LAMINA_TEST_OBSERVATION_CRASH_AFTER_COMMIT === '1') { const error = new Error('Injected observation crash after graphd commit.'); error.code = 'LAMINA_OBSERVATION_FAILED'; throw error; }
+    if (process.env.LAMINA_TEST_OBSERVATION_CRASH_AFTER_COMMIT === '1') {
+      const error = new Error('Injected observation crash after graphd commit.');
+      error.code = 'LAMINA_OBSERVATION_FAILED';
+      throw error;
+    }
+    activateGenerationPlan(plan);
+    commitGenerationState(statePath, plan, { phase: 'committed' });
   };
   await once();
   if (!live) return;

--- a/packages/cli/lib/observe.mjs
+++ b/packages/cli/lib/observe.mjs
@@ -15,14 +15,18 @@ import {
   runtimeBudgetFromEnvironment,
 } from './runtime-budget.mjs';
 import { releaseGraphdBeforeObservation, runWithRuntimeLifecycle } from './runtime-lifecycle.mjs';
+import {
+  OBSERVATION_IGNORE_PATTERNS,
+  observationInventorySnapshot,
+} from './source-inventory.mjs';
+import {
+  generationStatePath,
+  observationFreshnessContext,
+  readGenerationState,
+} from './observation-generation.mjs';
+import { brownfieldSignals } from './observation-runtime/node.mjs';
 
-const ignore = [
-  '**/.git/**', '**/.lamina/runs/**', '**/.lamina/runtime/**', '**/.lamina/runtime-cli/**',
-  '**/.agents/skills/**', '**/.codex/skills/**', '**/.claude/skills/**', '**/.opencode/skills/**',
-  '**/node_modules/**', '**/.venv*/**',
-  '**/__pycache__/**', '**/.next/**', '**/dist/**', '**/build/**', '**/coverage/**',
-  '**/benchmarks/results/**', '**/evals/fixtures/.vendor-tmp*/**',
-];
+const ignore = OBSERVATION_IGNORE_PATTERNS;
 
 function check(pass, expected, actual) {
   return { pass, expected, actual };
@@ -252,6 +256,9 @@ export async function runObservation({ cwd = process.cwd(), live = false, invali
       },
       ...(compatibilityRecovery ? { compatibility_recovery: compatibilityRecovery } : {}),
       ...(workerDiagnostics.length ? { worker_diagnostics: workerDiagnostics } : {}),
+      ...(readGenerationState(generationStatePath(paths.cocoindex)).commit_phase === 'pending'
+        ? { interrupted_recovery: { commit_phase: 'pending', freshness: observationFreshnessContext(cwd) } }
+        : {}),
       troubleshooting: completion.failed_checks.some((item) => item.startsWith('status.'))
         ? 'Reinstall or restart Lamina if graphd still lacks the required status contract.'
         : 'Run `lamina graph rebuild-observations` only when the reported target generation is genuinely incomplete or corrupted.',
@@ -274,6 +281,11 @@ export async function runObservation({ cwd = process.cwd(), live = false, invali
       unsupported_sources: observed.unsupported,
       stale_snapshots: observed.source_revisions.filter((item) => item !== paths.source_revision),
       limitations: observed.limitations,
+      source_inventory: observationInventorySnapshot(cwd, {
+        sourceRevision: paths.source_revision,
+        sourceRoot: paths.root,
+        extractSignals: brownfieldSignals,
+      }),
     } : undefined,
   };
   }, { live, mutation: true });

--- a/packages/cli/lib/retrieval-generation.mjs
+++ b/packages/cli/lib/retrieval-generation.mjs
@@ -1,0 +1,215 @@
+/** Retrieval generation, membership digests, and interrupted recovery (#73).
+ *
+ * Derived retrieval state only — graphd remains the sole Ladybug writer.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { sha256 as contractSha256 } from '../../../benchmarks/runtime-baseline-v1/contract.mjs';
+import { digest, repositoryContext } from './graph-runtime/util.mjs';
+import { enumerateRetrievalCandidatePaths, gitByteCompare } from './source-inventory.mjs';
+
+export const RETRIEVAL_GENERATION_SCHEMA = 'lamina.retrieval-generation/v1';
+export const GENERATION_STATE_FILE = 'retrieval-generation-state.json';
+
+export function retrievalFreshnessContext(cwd = process.cwd(), {
+  graph_version = '',
+  model_digest = '',
+  schema_version = 1,
+  observation_generation = '',
+  observation_membership_digest = contractSha256(''),
+} = {}) {
+  const repository = repositoryContext(cwd);
+  return Object.freeze({
+    source_revision: repository.source_revision,
+    repository_revision: repository.revision || '',
+    branch: repository.branch,
+    worktree: repository.root,
+    graph_version,
+    model_digest,
+    schema_version,
+    observation_generation,
+    observation_membership_digest,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function retrievalMembershipDigest(documents) {
+  const entries = (documents || [])
+    .map((item) => ({
+      content_hash: item.content_hash,
+      id: item.id,
+      logical_key: item.logical_key,
+    }))
+    .sort((left, right) => gitByteCompare(left.logical_key, right.logical_key))
+    .map((item) => `${item.logical_key}\0${item.content_hash}\0${item.id}`);
+  return contractSha256(entries.join('\n'));
+}
+
+export function retrievalGenerationId({ identity, ...freshness }) {
+  return digest('retrieval_generation', {
+    identity,
+    graph_version: freshness.graph_version,
+    source_revision: freshness.source_revision,
+    repository_revision: freshness.repository_revision,
+    branch: freshness.branch,
+    worktree: freshness.worktree,
+    model_digest: freshness.model_digest,
+    schema_version: freshness.schema_version,
+    observation_generation: freshness.observation_generation || '',
+    observation_membership_digest: freshness.observation_membership_digest || contractSha256(''),
+  });
+}
+
+export function generationStatePath(contextDir) {
+  return path.join(contextDir, GENERATION_STATE_FILE);
+}
+
+export function emptyGenerationState() {
+  return {
+    schema: RETRIEVAL_GENERATION_SCHEMA,
+    version: 1,
+    generation: null,
+    source_revision: null,
+    repository_revision: '',
+    branch: null,
+    worktree: null,
+    graph_version: null,
+    model_digest: null,
+    schema_version: 1,
+    observation_generation: '',
+    observation_membership_digest: contractSha256(''),
+    index_digest: contractSha256(''),
+    membership_digest: contractSha256(''),
+    commit_phase: 'committed',
+    non_canonical: true,
+    writes_product_truth: false,
+  };
+}
+
+export function readGenerationState(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    if (parsed?.schema !== RETRIEVAL_GENERATION_SCHEMA) return emptyGenerationState();
+    return {
+      ...emptyGenerationState(),
+      ...parsed,
+    };
+  } catch {
+    return emptyGenerationState();
+  }
+}
+
+export function writeGenerationState(statePath, state) {
+  const normalized = Object.freeze({
+    ...state,
+    schema: RETRIEVAL_GENERATION_SCHEMA,
+    version: 1,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+  fs.mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(statePath, `${JSON.stringify(normalized, null, 2)}\n`, { mode: 0o600 });
+  return normalized;
+}
+
+export function freshnessChanged(previous, current) {
+  return !previous
+    || previous.source_revision !== current.source_revision
+    || previous.repository_revision !== current.repository_revision
+    || previous.branch !== current.branch
+    || previous.worktree !== current.worktree
+    || previous.graph_version !== current.graph_version
+    || previous.model_digest !== current.model_digest
+    || Number(previous.schema_version) !== Number(current.schema_version)
+    || previous.observation_generation !== current.observation_generation
+    || previous.observation_membership_digest !== current.observation_membership_digest;
+}
+
+export function interruptedRecoveryNeeded(previous, { generation, freshness }) {
+  if (!previous || previous.generation !== generation) return false;
+  if (previous.commit_phase !== 'pending') return false;
+  return !freshnessChanged(previous, freshness);
+}
+
+export function planRetrievalSync({
+  repositoryRoot,
+  identity,
+  freshness,
+  previous,
+  includeUntracked = false,
+}) {
+  const generation = retrievalGenerationId({ identity, ...freshness });
+  const sourcePaths = enumerateRetrievalCandidatePaths(repositoryRoot, { includeUntracked });
+  const fullReconcile = previous.generation !== generation || freshnessChanged(previous, freshness);
+  const interrupted = interruptedRecoveryNeeded(previous, { generation, freshness });
+  return Object.freeze({
+    generation,
+    identity,
+    freshness,
+    source_paths: Object.freeze(sourcePaths),
+    full_reconcile: fullReconcile,
+    interrupted_recovery: interrupted,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function activateGenerationPlan(plan, status = null) {
+  if (!plan || typeof plan !== 'object') {
+    throw new Error('retrieval generation activation requires a plan');
+  }
+  if (status?.index_digest && plan.index_digest && status.index_digest !== plan.index_digest) {
+    const error = new Error('Retrieval generation index digest is invalid; it was not activated.');
+    error.code = 'LAMINA_RETRIEVAL_INCOMPLETE';
+    error.details = {
+      expected_digest: plan.index_digest,
+      actual_digest: status.index_digest,
+      non_canonical: true,
+    };
+    throw error;
+  }
+  if (status?.committed_count !== undefined && status?.expected_count !== undefined) {
+    if (Number(status.committed_count) !== Number(status.expected_count)) {
+      const error = new Error('Retrieval generation item count is incomplete; it was not activated.');
+      error.code = 'LAMINA_RETRIEVAL_INCOMPLETE';
+      error.details = {
+        expected_count: status.expected_count,
+        committed_count: status.committed_count,
+        non_canonical: true,
+      };
+      throw error;
+    }
+  }
+  return Object.freeze({
+    generation: plan.generation,
+    index_digest: plan.index_digest || status?.index_digest || plan.membership_digest,
+    membership_digest: plan.membership_digest || plan.index_digest,
+    committed: true,
+    interrupted_recovery: plan.interrupted_recovery,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function commitGenerationState(statePath, plan, status, { phase = 'committed' } = {}) {
+  return writeGenerationState(statePath, {
+    schema: RETRIEVAL_GENERATION_SCHEMA,
+    version: 1,
+    generation: plan.generation,
+    source_revision: plan.freshness.source_revision,
+    repository_revision: plan.freshness.repository_revision,
+    branch: plan.freshness.branch,
+    worktree: plan.freshness.worktree,
+    graph_version: plan.freshness.graph_version,
+    model_digest: plan.freshness.model_digest,
+    schema_version: plan.freshness.schema_version,
+    observation_generation: plan.freshness.observation_generation,
+    observation_membership_digest: plan.freshness.observation_membership_digest,
+    index_digest: status?.index_digest || plan.index_digest || contractSha256(''),
+    membership_digest: status?.index_digest || plan.membership_digest || contractSha256(''),
+    commit_phase: phase,
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}

--- a/packages/cli/lib/retrieval-runtime/constants.mjs
+++ b/packages/cli/lib/retrieval-runtime/constants.mjs
@@ -1,4 +1,4 @@
-export const RETRIEVAL_SCHEMA_VERSION = 1;
+export const RETRIEVAL_SCHEMA_VERSION = 2;
 export const RETRIEVAL_DIMENSIONS = 768;
 export const RETRIEVAL_RRF_K = 60;
 export const RETRIEVAL_LIMIT = 12;
@@ -34,6 +34,8 @@ export const RETRIEVAL_SCHEMA = Object.freeze([
     branch STRING,
     worktree STRING,
     model_digest STRING,
+    observation_generation STRING,
+    observation_membership_digest STRING,
     index_digest STRING,
     schema_version INT64,
     expected_count INT64,
@@ -49,6 +51,8 @@ export const RETRIEVAL_SCHEMA = Object.freeze([
     branch STRING,
     worktree STRING,
     model_digest STRING,
+    observation_generation STRING,
+    observation_membership_digest STRING,
     index_digest STRING,
     schema_version INT64,
     expected_count INT64,

--- a/packages/cli/lib/retrieval-runtime/process.mjs
+++ b/packages/cli/lib/retrieval-runtime/process.mjs
@@ -7,12 +7,24 @@ import { graphSocketChildPath, repositoryContext, runtimePaths } from '../graph-
 import { RETRIEVAL_SCHEMA_VERSION } from './constants.mjs';
 import { verifyRetrievalModel, verifyRetrievalRuntimeAssets } from './assets.mjs';
 import { retrievalIdentity, workflowDocuments } from './documents.mjs';
-import { workerThreadEnvironment } from '../runtime-budget.mjs';
+import { workerThreadEnvironment, retrievalBatchEnvironment } from '../runtime-budget.mjs';
 import {
   assertCompatibleRuntimeIdentity,
   releaseGraphdBeforeObservation,
   runWithRuntimeLifecycle,
 } from '../runtime-lifecycle.mjs';
+import {
+  generationStatePath as observationGenerationStatePath,
+  readGenerationState as readObservationGenerationState,
+} from '../observation-generation.mjs';
+import {
+  activateGenerationPlan,
+  commitGenerationState,
+  generationStatePath as retrievalGenerationStatePath,
+  planRetrievalSync,
+  readGenerationState as readRetrievalGenerationState,
+  retrievalFreshnessContext,
+} from '../retrieval-generation.mjs';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -64,6 +76,7 @@ function workerEnvironment(cwd, graphd, model) {
   return {
     ...process.env,
     ...workerThreadEnvironment(),
+    ...retrievalBatchEnvironment(),
     LAMINA_SOURCE_ROOT: paths.root,
     LAMINA_GRAPHD_ENDPOINT: graphSocketChildPath(paths),
     LAMINA_GRAPHD_TOKEN: graphd.auth_token,
@@ -103,6 +116,7 @@ function runWorker(args, { cwd, input = null, graphd, model }) {
 
 async function retrievalSnapshot(cwd, model) {
   const repository = repositoryContext(cwd);
+  const paths = runtimePaths(cwd);
   const status = await graphRequest('status', {}, cwd);
   const workflowQuery = await graphRequest('graph.query', { at: 'HEAD', kind: 'workflow' }, cwd);
   const workflowIds = workflowQuery.resources.map((item) => item.id);
@@ -110,11 +124,27 @@ async function retrievalSnapshot(cwd, model) {
     ? await graphRequest('work.context', { workflows: workflowIds, request: '' }, cwd)
     : { graph_version: { id: status.graph_version }, workflows: [] };
   const identity = retrievalIdentity(cwd);
+  const observationState = readObservationGenerationState(observationGenerationStatePath(paths.cocoindex));
+  const freshness = retrievalFreshnessContext(cwd, {
+    graph_version: graph.graph_version?.id || status.graph_version,
+    model_digest: model.digest,
+    schema_version: RETRIEVAL_SCHEMA_VERSION,
+    observation_generation: observationState.generation || '',
+    observation_membership_digest: observationState.membership_digest || '',
+  });
+  const plan = planRetrievalSync({
+    repositoryRoot: cwd,
+    identity: identity.identity,
+    freshness,
+    previous: readRetrievalGenerationState(retrievalGenerationStatePath(paths.context)),
+  });
   return {
     schema: 'lamina.retrieval-snapshot/v1',
     ...identity,
-    graph_version: graph.graph_version?.id || status.graph_version,
-    source_revision: repository.source_revision,
+    ...freshness,
+    generation: plan.generation,
+    source_paths: plan.source_paths,
+    graph_version: freshness.graph_version,
     model_digest: model.digest,
     schema_version: RETRIEVAL_SCHEMA_VERSION,
     workflows: workflowDocuments(graph.workflows),
@@ -124,12 +154,15 @@ async function retrievalSnapshot(cwd, model) {
 function statusParams(snapshot, includeDocuments = false) {
   return {
     identity: snapshot.identity,
+    generation: snapshot.generation,
     graph_version: snapshot.graph_version,
     source_revision: snapshot.source_revision,
     repository_revision: snapshot.repository_revision,
     branch: snapshot.branch,
     worktree: snapshot.worktree,
     model_digest: snapshot.model_digest,
+    observation_generation: snapshot.observation_generation || '',
+    observation_membership_digest: snapshot.observation_membership_digest || '',
     schema_version: snapshot.schema_version,
     include_documents: includeDocuments,
   };
@@ -168,6 +201,20 @@ export async function ensureRetrieval(
   if (!status.fresh) {
     const paths = runtimePaths(cwd);
     fs.mkdirSync(paths.context, { recursive: true, mode: 0o700 });
+    const retrievalStatePath = retrievalGenerationStatePath(paths.context);
+    const plan = planRetrievalSync({
+      repositoryRoot: cwd,
+      identity: snapshot.identity,
+      freshness: retrievalFreshnessContext(cwd, {
+        graph_version: snapshot.graph_version,
+        model_digest: snapshot.model_digest,
+        schema_version: snapshot.schema_version,
+        observation_generation: snapshot.observation_generation || '',
+        observation_membership_digest: snapshot.observation_membership_digest || '',
+      }),
+      previous: readRetrievalGenerationState(retrievalStatePath),
+    });
+    commitGenerationState(retrievalStatePath, plan, null, { phase: 'pending' });
     const inputFile = path.join(paths.context, `retrieval-input-${process.pid}.json`);
     fs.writeFileSync(inputFile, `${JSON.stringify({ ...snapshot, previous: status.documents || {} })}\n`, {
       mode: 0o600,
@@ -183,6 +230,12 @@ export async function ensureRetrieval(
       error.code = 'LAMINA_RETRIEVAL_INCOMPLETE';
       throw error;
     }
+    activateGenerationPlan(plan, {
+      index_digest: status.manifest?.index_digest,
+      expected_count: status.counts.expected,
+      committed_count: status.counts.committed,
+    });
+    commitGenerationState(retrievalStatePath, plan, status.manifest, { phase: 'committed' });
   }
   return { snapshot, status, model, graphd };
   }, { mutation: true });

--- a/packages/cli/lib/retrieval-runtime/store.mjs
+++ b/packages/cli/lib/retrieval-runtime/store.mjs
@@ -22,6 +22,8 @@ const MANIFEST_RETURN = `m.identity AS identity, m.generation AS generation,
   m.graph_version AS graph_version, m.source_revision AS source_revision,
   m.repository_revision AS repository_revision, m.branch AS branch,
   m.worktree AS worktree, m.model_digest AS model_digest,
+  m.observation_generation AS observation_generation,
+  m.observation_membership_digest AS observation_membership_digest,
   m.index_digest AS index_digest, m.schema_version AS schema_version,
   m.expected_count AS expected_count`;
 const ACTIVE_MANIFEST_RETURN = `${MANIFEST_RETURN},
@@ -243,7 +245,41 @@ export class RetrievalStore {
       this.connection.initSync();
       for (const statement of RETRIEVAL_SCHEMA) this.connection.querySync(statement);
     }
+    this.migrateRetrievalSchema();
     this.recoverInterruptedPendingGenerations();
+  }
+
+  retrievalSchemaSupportsObservationGeneration() {
+    try {
+      this.query('MATCH (m:RetrievalManifest) RETURN m.observation_generation AS observation_generation LIMIT 1');
+      this.query('MATCH (p:RetrievalPending) RETURN p.observation_generation AS observation_generation LIMIT 1');
+      return true;
+    } catch (error) {
+      const message = String(error?.message || error);
+      if (message.includes('observation_generation') || message.includes('observation_membership_digest')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  migrateRetrievalSchema() {
+    const manifests = this.query(
+      'MATCH (m:RetrievalManifest) RETURN m.schema_version AS schema_version',
+    );
+    if (manifests.some((row) => Number(row.schema_version) < RETRIEVAL_SCHEMA_VERSION)) {
+      // Fall through to rebuild below.
+    } else if (this.retrievalSchemaSupportsObservationGeneration()) {
+      return;
+    }
+    this.close();
+    for (const file of [this.paths.retrieval, `${this.paths.retrieval}.wal`]) {
+      fs.rmSync(file, { recursive: true, force: true });
+    }
+    this.database = null;
+    this.connection = null;
+    this.extensionsLoaded = false;
+    this.ensureOpen();
   }
 
   recoverInterruptedPendingGenerations() {
@@ -422,6 +458,8 @@ export class RetrievalStore {
       manifest.branch === params.branch &&
       manifest.worktree === params.worktree &&
       manifest.model_digest === params.model_digest &&
+      (manifest.observation_generation || '') === (params.observation_generation || '') &&
+      (manifest.observation_membership_digest || '') === (params.observation_membership_digest || '') &&
       Number(manifest.schema_version) === RETRIEVAL_SCHEMA_VERSION;
     let documents;
     const documentGeneration = manifest || pending;
@@ -517,12 +555,16 @@ export class RetrievalStore {
             identity: $identity, generation: $generation, graph_version: $graph_version,
             source_revision: $source_revision, repository_revision: $repository_revision,
             branch: $branch, worktree: $worktree, model_digest: $model_digest,
+            observation_generation: $observation_generation,
+            observation_membership_digest: $observation_membership_digest,
             index_digest: $index_digest, schema_version: $schema_version,
             expected_count: $expected_count, started_at: $started_at
           })`,
           {
             ...manifest,
             repository_revision: manifest.repository_revision || '',
+            observation_generation: manifest.observation_generation || '',
+            observation_membership_digest: manifest.observation_membership_digest || '',
             started_at: new Date().toISOString(),
           },
         );
@@ -534,7 +576,9 @@ export class RetrievalStore {
       if (!pending || pending.generation !== generation ||
           pending.graph_version !== manifest.graph_version ||
           pending.source_revision !== manifest.source_revision ||
-          pending.model_digest !== manifest.model_digest) {
+          pending.model_digest !== manifest.model_digest ||
+          (pending.observation_generation || '') !== (manifest.observation_generation || '') ||
+          (pending.observation_membership_digest || '') !== (manifest.observation_membership_digest || '')) {
         throw retrievalFailure('Retrieval batch does not match the pending generation.');
       }
       for (const item of upserts) {
@@ -625,12 +669,16 @@ export class RetrievalStore {
             identity: $identity, generation: $generation, graph_version: $graph_version,
             source_revision: $source_revision, repository_revision: $repository_revision,
             branch: $branch, worktree: $worktree, model_digest: $model_digest,
+            observation_generation: $observation_generation,
+            observation_membership_digest: $observation_membership_digest,
             index_digest: $index_digest, schema_version: $schema_version,
             expected_count: $expected_count, committed_count: $committed_count,
             updated_at: $updated_at
           })`,
           {
             ...pending,
+            observation_generation: pending.observation_generation || '',
+            observation_membership_digest: pending.observation_membership_digest || '',
             committed_count: documents.length,
             updated_at: new Date().toISOString(),
           },

--- a/packages/cli/lib/runtime-budget.mjs
+++ b/packages/cli/lib/runtime-budget.mjs
@@ -28,6 +28,7 @@ export function runtimeBudgetFromEnvironment(env = process.env) {
     worker_threads: readPositiveInt(env.LAMINA_RUNTIME_WORKER_THREADS, 1),
     observation_workers_max: readPositiveInt(env.LAMINA_RUNTIME_OBSERVATION_WORKERS, 1),
     observation_retries_max: readPositiveInt(env.LAMINA_RUNTIME_OBSERVATION_RETRIES, 0),
+    retrieval_batch_size: readPositiveInt(env.LAMINA_RUNTIME_RETRIEVAL_BATCH, 16),
     defer_graphd_compat_recovery: env.LAMINA_RUNTIME_DEFER_GRAPHD_COMPAT_RECOVERY !== '0',
     idle_graphd_shutdown_ms: readPositiveInt(env.LAMINA_RUNTIME_IDLE_GRAPHD_SHUTDOWN_MS, 0),
   });
@@ -78,6 +79,13 @@ export function workerThreadEnvironment(budget = runtimeBudgetFromEnvironment())
   return threadLimitEnvironment(budget.worker_threads);
 }
 
+export function retrievalBatchEnvironment(budget = runtimeBudgetFromEnvironment()) {
+  if (!budget) return {};
+  return Object.freeze({
+    LAMINA_RUNTIME_RETRIEVAL_BATCH: String(Math.max(1, budget.retrieval_batch_size)),
+  });
+}
+
 /** CocoIndex observation: serial component builds under pids.max; inflight>1 fans out processes. */
 export function observationWorkerThreadEnvironment(budget = runtimeBudgetFromEnvironment()) {
   if (!budget) return {};
@@ -104,5 +112,6 @@ export function graphdThreadEnvironment(budget = runtimeBudgetFromEnvironment())
 
 export function maxObservationAttempts(budget = runtimeBudgetFromEnvironment()) {
   if (!budget) return 2;
-  return Math.max(1, budget.observation_workers_max + budget.observation_retries_max);
+  // Bounded topology still needs one worker retry for interrupted observation recovery.
+  return Math.max(2, budget.observation_workers_max + budget.observation_retries_max);
 }

--- a/packages/cli/lib/source-inventory.mjs
+++ b/packages/cli/lib/source-inventory.mjs
@@ -1,0 +1,380 @@
+/** Git-aware source inventory for observation and runtime-baseline authority (#71).
+ *
+ * Observation inventory emits rebuildable source-derived facts only. It never
+ * writes canonical product truth or approved graph statements.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { isExcludedPath, loadManifest, sha256 as contractSha256 } from '../../../benchmarks/runtime-baseline-v1/contract.mjs';
+
+export const SOURCE_INVENTORY_SCHEMA = 'lamina.source-inventory/v1';
+export const SOURCE_CONFIG_NAMES = new Set(['package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml']);
+export const MAX_SOURCE_LOC_BYTES = 4 * 1024 * 1024;
+
+export const OBSERVATION_COVERAGE_CATEGORIES = Object.freeze([
+  'entry_points', 'commands', 'routes', 'handlers', 'schemas', 'entities',
+  'state_transitions', 'permissions', 'events', 'tests', 'documentation',
+  'personas', 'feature_flags', 'dependencies',
+]);
+
+export const OBSERVATION_IGNORE_PATTERNS = Object.freeze([
+  '**/.git/**', '**/.lamina/runs/**', '**/.lamina/runtime/**', '**/.lamina/runtime-cli/**',
+  '**/.agents/skills/**', '**/.codex/skills/**', '**/.claude/skills/**', '**/.opencode/skills/**',
+  '**/node_modules/**', '**/.venv*/**',
+  '**/__pycache__/**', '**/.next/**', '**/dist/**', '**/build/**', '**/coverage/**',
+  '**/benchmarks/results/**', '**/evals/fixtures/.vendor-tmp*/**',
+]);
+
+const EXCLUSION_REASON_BY_RULE = Object.freeze({
+  '.git': 'git_metadata',
+  '.agents/skills': 'agent_skill_mirror',
+  '.claude/skills': 'agent_skill_mirror',
+  '.codex/skills': 'agent_skill_mirror',
+  '.opencode/skills': 'agent_skill_mirror',
+  '.lamina/runs': 'lamina_run_artifacts',
+  '.lamina/runtime': 'lamina_runtime_state',
+  '.lamina/runtime-cli': 'lamina_runtime_cli',
+  node_modules: 'dependency_root',
+  __pycache__: 'python_cache',
+  '.venv*': 'python_virtualenv',
+  '.next': 'frontend_build_cache',
+  dist: 'build_output',
+  build: 'build_output',
+  coverage: 'test_coverage_output',
+  'benchmarks/results': 'benchmark_results',
+  'evals/fixtures/.vendor-tmp*': 'vendored_eval_scratch',
+});
+
+export const BASELINE_EXCLUSION_RULES = Object.freeze(loadManifest().manifest.exclusions);
+
+export const gitByteCompare = (left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right));
+
+export function safeRepositoryPath(value) {
+  return typeof value === 'string' && value.length > 0 && !value.includes('\0')
+    && !value.includes('\\') && !value.startsWith('/') && !/^[A-Za-z]:/.test(value)
+    && value.split('/').every((piece) => piece && piece !== '.' && piece !== '..');
+}
+
+function trustedGit(repository, args, { encoding = 'utf8' } = {}) {
+  return execFileSync('git', args, {
+    cwd: repository,
+    encoding,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+function listGitPaths(repository, args) {
+  try {
+    const output = trustedGit(repository, args, { encoding: 'utf8' });
+    return output.split('\0').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function classifyExclusion(relative, exclusions = BASELINE_EXCLUSION_RULES) {
+  if (!safeRepositoryPath(relative)) return 'unsafe_path';
+  if (!isExcludedPath(relative, exclusions)) return null;
+  const pieces = relative.split('/');
+  for (const rule of exclusions) {
+    const normalized = rule.replace(/\*$/, '');
+    const matches = relative === normalized || relative.startsWith(`${normalized}/`)
+      || (rule.endsWith('*') && relative.startsWith(normalized));
+    if (!matches) continue;
+    if (EXCLUSION_REASON_BY_RULE[rule]) return EXCLUSION_REASON_BY_RULE[rule];
+    if (pieces.includes(rule.replace(/\*$/, ''))) return EXCLUSION_REASON_BY_RULE[rule] || rule;
+    return rule;
+  }
+  if (pieces.includes('.git')) return EXCLUSION_REASON_BY_RULE['.git'];
+  if (pieces.includes('node_modules')) return EXCLUSION_REASON_BY_RULE.node_modules;
+  if (pieces.includes('__pycache__')) return EXCLUSION_REASON_BY_RULE.__pycache__;
+  if (pieces.some((piece) => /^\.venv/.test(piece))) return EXCLUSION_REASON_BY_RULE['.venv*'];
+  return 'excluded';
+}
+
+export function isInventoryExcluded(relative, exclusions = BASELINE_EXCLUSION_RULES) {
+  return classifyExclusion(relative, exclusions) !== null;
+}
+
+export function enumerateGitInventoryPaths(repository, {
+  includeUntracked = true,
+  includeTracked = true,
+} = {}) {
+  const physical = fs.realpathSync.native(repository);
+  const paths = new Set();
+  if (includeTracked) {
+    for (const relative of listGitPaths(physical, ['ls-files', '-z'])) paths.add(relative);
+  }
+  if (includeUntracked) {
+    for (const relative of listGitPaths(physical, ['ls-files', '--others', '--exclude-standard', '-z'])) {
+      paths.add(relative);
+    }
+  }
+  return [...paths].sort(gitByteCompare);
+}
+
+export function enumerateObservationPaths(repository, {
+  exclusions = BASELINE_EXCLUSION_RULES,
+  includeUntracked = true,
+} = {}) {
+  const physical = fs.realpathSync.native(repository);
+  return enumerateGitInventoryPaths(physical, { includeUntracked }).flatMap((relative) => {
+    const reason = classifyExclusion(relative, exclusions);
+    if (reason) return [];
+    const absolute = path.join(physical, relative);
+    let stat;
+    try { stat = fs.lstatSync(absolute); } catch { return []; }
+    if (!stat.isFile()) return [];
+    return [Object.freeze({
+      path: relative,
+      bytes: stat.size,
+      content_sha256: null,
+      exclusion: null,
+    })];
+  });
+}
+
+export function sourcePathIdentity(relative, content) {
+  if (!safeRepositoryPath(relative)) throw new Error('source path identity requires a safe repository-relative path');
+  const bytes = Buffer.isBuffer(content) ? content : Buffer.from(content);
+  const contentDigest = crypto.createHash('sha256').update(bytes).digest('hex');
+  const blobOid = crypto.createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex');
+  return Object.freeze({
+    schema: SOURCE_INVENTORY_SCHEMA,
+    source_key: relative,
+    logical_key: relative,
+    content_sha256: contentDigest,
+    blob_oid: blobOid,
+    byte_length: bytes.length,
+    identity_digest: contractSha256(JSON.stringify({
+      source_key: relative,
+      content_sha256: contentDigest,
+      byte_length: bytes.length,
+    })),
+  });
+}
+
+export function inventoryPathsDigest(paths) {
+  return contractSha256([...paths].sort(gitByteCompare).join('\n'));
+}
+
+export function summarizePathInventory(paths, repository, manifest, fixture, {
+  exclusions = manifest.exclusions,
+  sourceNames = SOURCE_CONFIG_NAMES,
+  maxSourceLocBytes = MAX_SOURCE_LOC_BYTES,
+} = {}) {
+  const physical = fs.realpathSync.native(repository);
+  const sourceExtensions = new Set(manifest.source_extensions);
+  const retrievalExtensions = new Set(manifest.retrieval_extensions);
+  const observationPaths = [];
+  const retrievalPaths = [];
+  const entries = [];
+  let trackedBytes = 0;
+  let observationBytes = 0;
+  let retrievalBytes = 0;
+  let sourceFiles = 0;
+  let sourceBytes = 0;
+  let sourceLoc = 0;
+
+  for (const relative of [...paths].sort(gitByteCompare)) {
+    if (!safeRepositoryPath(relative)) continue;
+    const absolute = path.join(physical, relative);
+    let stat;
+    try { stat = fs.statSync(absolute); } catch { continue; }
+    if (!stat.isFile()) continue;
+    trackedBytes += stat.size;
+    const exclusion = classifyExclusion(relative, exclusions);
+    const contribution = {
+      tracked_bytes: stat.size,
+      observation_included: false,
+      observation_bytes: 0,
+      retrieval_included: false,
+      retrieval_bytes: 0,
+      source_included: false,
+      source_bytes: 0,
+      source_loc: 0,
+      exclusion_reason: exclusion,
+    };
+    let content = null;
+    if (!exclusion) {
+      observationPaths.push(relative);
+      observationBytes += stat.size;
+      contribution.observation_included = true;
+      contribution.observation_bytes = stat.size;
+    }
+    const extension = path.posix.extname(relative).toLowerCase();
+    if (!exclusion && retrievalExtensions.has(extension) && stat.size <= manifest.retrieval_max_file_bytes) {
+      try {
+        content = fs.readFileSync(absolute);
+        new TextDecoder('utf-8', { fatal: true }).decode(content);
+        retrievalPaths.push(relative);
+        retrievalBytes += stat.size;
+        contribution.retrieval_included = true;
+        contribution.retrieval_bytes = stat.size;
+      } catch {}
+    }
+    if (sourceExtensions.has(extension) || sourceNames.has(path.posix.basename(relative))) {
+      sourceFiles += 1;
+      sourceBytes += stat.size;
+      contribution.source_included = true;
+      contribution.source_bytes = stat.size;
+      if (stat.size <= maxSourceLocBytes) {
+        if (!content) {
+          try { content = fs.readFileSync(absolute); } catch { content = null; }
+        }
+        if (content) {
+          const lines = content.toString('utf8').split(/\r?\n/).filter((line) => line.trim()).length;
+          sourceLoc += lines;
+          contribution.source_loc = lines;
+        }
+      }
+    }
+    entries.push(Object.freeze({ path: relative, ...contribution }));
+  }
+
+  if (fixture?.source_loc) {
+    if (sourceLoc < fixture.source_loc.minimum || sourceLoc > fixture.source_loc.maximum) {
+      throw new Error(`fixture ${fixture.id} source LOC ${sourceLoc} is outside its frozen class`);
+    }
+  }
+
+  const inventory = Object.freeze({
+    tracked_files: paths.length,
+    tracked_bytes: trackedBytes,
+    tracked_source_files: sourceFiles,
+    tracked_source_bytes: sourceBytes,
+    tracked_source_loc: sourceLoc,
+    observation_indexed_files: observationPaths.length,
+    observation_indexed_bytes: observationBytes,
+    observation_paths_digest: inventoryPathsDigest(observationPaths),
+    retrieval_candidate_files: retrievalPaths.length,
+    retrieval_candidate_bytes: retrievalBytes,
+    retrieval_paths_digest: inventoryPathsDigest(retrievalPaths),
+  });
+  return Object.freeze({
+    inventory,
+    entries,
+    observation_paths: Object.freeze(observationPaths),
+    retrieval_paths: Object.freeze(retrievalPaths),
+    inventory_digest: contractSha256(JSON.stringify(Object.fromEntries(
+      Object.keys(inventory).sort().map((key) => [key, inventory[key]]),
+    ))),
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function enumerateRetrievalCandidatePaths(repository, {
+  manifest = loadManifest().manifest,
+  exclusions = manifest.exclusions,
+  includeUntracked = false,
+} = {}) {
+  const paths = enumerateGitInventoryPaths(repository, { includeUntracked });
+  return summarizePathInventory(paths, repository, manifest, null, { exclusions }).retrieval_paths;
+}
+
+export function summarizeRepositoryInventory(repository, { manifest, fixture } = {}) {
+  const loaded = manifest ? { manifest } : loadManifest();
+  const resolvedManifest = manifest || loaded.manifest;
+  const paths = enumerateGitInventoryPaths(repository, { includeUntracked: false });
+  const summary = summarizePathInventory(paths, repository, resolvedManifest, fixture);
+  return Object.freeze({
+    ...summary.inventory,
+    commit: fixture?.commit || null,
+    exclusion_rules: resolvedManifest.exclusions,
+    _retrieval_paths: summary.retrieval_paths,
+  });
+}
+
+export function buildCoverageFoundation(entries, {
+  readContent = true,
+  repository = null,
+  extractSignals,
+} = {}) {
+  if (typeof extractSignals !== 'function') {
+    throw new Error('buildCoverageFoundation requires the production brownfield signal extractor');
+  }
+  const coverage = Object.fromEntries(OBSERVATION_COVERAGE_CATEGORIES.map((category) => [category, []]));
+  const physical = repository ? fs.realpathSync.native(repository) : null;
+  for (const entry of entries) {
+    if (!entry.observation_included) continue;
+    let content;
+    if (readContent && physical) {
+      try { content = fs.readFileSync(path.join(physical, entry.path)); } catch { continue; }
+    } else {
+      continue;
+    }
+    const observed = extractSignals(entry.path, content);
+    for (const category of observed.categories) {
+      if (!coverage[category]) continue;
+      for (const signal of observed.signals?.[category] || []) {
+        if (!coverage[category].includes(signal)) coverage[category].push(signal);
+      }
+      if (!coverage[category].includes(entry.path) && category !== 'commands') {
+        coverage[category].push(entry.path);
+      }
+    }
+  }
+  const normalized = Object.fromEntries(Object.entries(coverage).map(([key, values]) => [
+    key,
+    [...new Set(values.map((value) => String(value).trim()).filter(Boolean))].sort().slice(0, 100),
+  ]));
+  const populated = Object.fromEntries(
+    Object.entries(normalized).filter(([, values]) => values.length),
+  );
+  return Object.freeze({
+    schema: 'lamina.source-inventory-coverage/v1',
+    categories: Object.freeze(populated),
+    category_counts: Object.freeze(Object.fromEntries(
+      Object.entries(populated).map(([key, values]) => [key, values.length]),
+    )),
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}
+
+export function observationInventorySnapshot(repository, {
+  manifest = loadManifest().manifest,
+  exclusions = manifest.exclusions,
+  sourceRevision = null,
+  sourceRoot = null,
+  extractSignals,
+} = {}) {
+  const physical = fs.realpathSync.native(repository);
+  const paths = enumerateObservationPaths(physical, { exclusions });
+  const entries = paths.map((item) => Object.freeze({
+    path: item.path,
+    tracked_bytes: item.bytes,
+    observation_included: true,
+    observation_bytes: item.bytes,
+    retrieval_included: false,
+    retrieval_bytes: 0,
+    source_included: false,
+    source_bytes: 0,
+    source_loc: 0,
+    exclusion_reason: null,
+  }));
+  const summary = summarizePathInventory(
+    paths.map((item) => item.path),
+    physical,
+    manifest,
+    null,
+    { exclusions },
+  );
+  return Object.freeze({
+    schema: SOURCE_INVENTORY_SCHEMA,
+    source_revision: sourceRevision,
+    source_root: sourceRoot || physical,
+    exclusion_rules: exclusions,
+    exclusion_roots: Object.freeze([...new Set(
+      entries.map((entry) => classifyExclusion(entry.path, exclusions)).filter(Boolean),
+    )].sort()),
+    paths: Object.freeze(paths),
+    inventory: summary.inventory,
+    coverage: buildCoverageFoundation(entries, { repository: physical, extractSignals }),
+    non_canonical: true,
+    writes_product_truth: false,
+  });
+}

--- a/packages/cli/retrieval_worker.py
+++ b/packages/cli/retrieval_worker.py
@@ -73,6 +73,15 @@ def _worker_thread_cap() -> int:
         return 1
 
 
+def _retrieval_batch_cap() -> int:
+    raw = os.environ.get("LAMINA_RUNTIME_RETRIEVAL_BATCH", "16")
+    try:
+        value = int(raw)
+        return max(1, value)
+    except ValueError:
+        return 16
+
+
 class Embedder:
     def __init__(self) -> None:
         self.test_only = os.environ.get("LAMINA_TEST_RETRIEVAL_EMBEDDER") == "deterministic"
@@ -277,10 +286,17 @@ def split_region(
         }
 
 
-def source_documents(root: pathlib.Path) -> list[dict[str, Any]]:
+def source_documents(root: pathlib.Path, candidates: list[str] | None = None) -> list[dict[str, Any]]:
     output = []
-    for file in tracked_files(root):
-        relative = file.relative_to(root).as_posix()
+    if candidates is None:
+        relative_paths = [
+            file.relative_to(root).as_posix()
+            for file in tracked_files(root)
+        ]
+    else:
+        relative_paths = sorted(candidates)
+    for relative in relative_paths:
+        file = root / relative
         if file.suffix.lower() not in TEXT_EXTENSIONS:
             continue
         try:
@@ -306,7 +322,8 @@ def prepare_documents(
     snapshot: dict[str, Any],
 ) -> tuple[list[dict[str, Any]], list[str], set[str]]:
     root = pathlib.Path(os.environ["LAMINA_SOURCE_ROOT"]).resolve()
-    documents = [*snapshot.get("workflows", []), *source_documents(root)]
+    source_paths = snapshot.get("source_paths")
+    documents = [*snapshot.get("workflows", []), *source_documents(root, source_paths)]
     previous = snapshot.get("previous", {})
     upserts = []
     member_ids = []
@@ -334,8 +351,8 @@ def prepare_documents(
         )
         pending.append(item)
         member_ids.append(item["id"])
-    for offset in range(0, len(pending), 16):
-        batch = pending[offset : offset + 16]
+    for offset in range(0, len(pending), _retrieval_batch_cap()):
+        batch = pending[offset : offset + _retrieval_batch_cap()]
         vectors = embedder.encode([item["text"] for item in batch])
         for item, embedding in zip(batch, vectors):
             item["embedding"] = embedding
@@ -377,8 +394,13 @@ def index_command(input_path: pathlib.Path) -> dict[str, Any]:
             "identity": snapshot["identity"],
             "graph_version": snapshot["graph_version"],
             "source_revision": snapshot["source_revision"],
+            "repository_revision": snapshot.get("repository_revision", ""),
+            "branch": snapshot.get("branch", ""),
+            "worktree": snapshot.get("worktree", ""),
             "model_digest": snapshot["model_digest"],
             "schema_version": snapshot["schema_version"],
+            "observation_generation": snapshot.get("observation_generation", ""),
+            "observation_membership_digest": snapshot.get("observation_membership_digest", ""),
         },
     )
     manifest = {
@@ -386,16 +408,21 @@ def index_command(input_path: pathlib.Path) -> dict[str, Any]:
         for key in (
             "identity", "graph_version", "source_revision", "repository_revision",
             "branch", "worktree", "model_digest", "schema_version",
+            "observation_generation", "observation_membership_digest",
         )
+        if key in snapshot
     }
     manifest.update(
         {
             "generation": generation,
             "expected_count": len(members),
             "index_digest": index_digest([current_by_id[item] for item in members]),
+            "observation_generation": snapshot.get("observation_generation", ""),
+            "observation_membership_digest": snapshot.get("observation_membership_digest", ""),
         }
     )
-    for offset in range(0, max(len(upserts), len(members), 1), 100):
+    batch_cap = _retrieval_batch_cap()
+    for offset in range(0, max(len(upserts), len(members), 1), batch_cap):
         graphd_request(
             "retrieval.apply",
             {
@@ -403,9 +430,9 @@ def index_command(input_path: pathlib.Path) -> dict[str, Any]:
                 "generation": generation,
                 "manifest": manifest,
                 "reset": offset == 0,
-                "upserts": upserts[offset : offset + 100],
-                "members": members[offset : offset + 100],
-                "deletes": deletes[offset : offset + 100],
+                "upserts": upserts[offset : offset + batch_cap],
+                "members": members[offset : offset + batch_cap],
+                "deletes": deletes[offset : offset + batch_cap],
                 "complete": False,
             },
         )

--- a/tests/observation_diagnostics_test.mjs
+++ b/tests/observation_diagnostics_test.mjs
@@ -93,7 +93,9 @@ try {
   assert.equal(failure.error.details.worker_diagnostics.length, 2);
   assert.ok(failure.error.details.worker_diagnostics.every((item) => item.ok === false));
   assert.equal(failure.error.details.daemon.protocol_version, 9);
-  daemonPid = parseDaemonLock(fs.readFileSync(runtimePaths(root).lock, 'utf8'))?.pid;
+  try {
+    daemonPid = parseDaemonLock(fs.readFileSync(runtimePaths(root).lock, 'utf8'))?.pid;
+  } catch {}
 } finally {
   if (daemonPid) {
     try { await stopIncompatibleServer(runtimePaths(root), daemonPid); } catch {}

--- a/tests/observation_generation_test.mjs
+++ b/tests/observation_generation_test.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { brownfieldSignals } from '../packages/cli/lib/observation-runtime/node.mjs';
+import {
+  activateGenerationPlan,
+  commitGenerationState,
+  emptyGenerationState,
+  generationStatePath,
+  interruptedRecoveryNeeded,
+  observationFreshnessContext,
+  observationMembershipDigest,
+  planObservationSync,
+  readGenerationState,
+} from '../packages/cli/lib/observation-generation.mjs';
+import { removeTemporaryTree } from './test-util.mjs';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lamina-observation-generation-'));
+const git = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+const statePath = generationStatePath(path.join(root, '.git', 'lamina', 'cocoindex'));
+
+try {
+  git(['init', '-b', 'main']);
+  git(['config', 'user.email', 'test@lamina.invalid']);
+  git(['config', 'user.name', 'Lamina Test']);
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'alpha.ts'), 'export const alpha = 1;\n');
+  fs.writeFileSync(path.join(root, 'src', 'beta.ts'), 'export const beta = 2;\n');
+  git(['add', 'src']);
+  git(['commit', '-m', 'fixture']);
+
+  const freshness = observationFreshnessContext(root);
+  assert.equal(freshness.non_canonical, true);
+  assert.equal(freshness.writes_product_truth, false);
+  assert.equal(freshness.branch, 'main');
+  assert.equal(freshness.worktree, fs.realpathSync.native(root));
+
+  const snapshot = {
+    product: path.basename(path.dirname(path.join(root, '.git'))),
+    source_revision: freshness.source_revision,
+    source_root: root,
+    ignore_policy_digest: 'ignore-test',
+    extractor_set_digest: 'extractor-test',
+  };
+
+  const committedFreshness = observationFreshnessContext(root);
+  const initial = planObservationSync({
+    repositoryRoot: root,
+    generation: 'generation-a',
+    snapshot,
+    freshness: committedFreshness,
+    previous: emptyGenerationState(),
+    extractSignals: brownfieldSignals,
+  });
+  assert.equal(initial.expected_count, 2);
+  assert.equal(initial.envelopes.length, 2);
+  assert.equal(initial.deletes.length, 0);
+  assert.equal(initial.membership_digest, observationMembershipDigest(initial.records));
+  activateGenerationPlan(initial);
+
+  const previousCommitted = {
+    ...emptyGenerationState(),
+    generation: 'generation-a',
+    ...committedFreshness,
+    records: initial.records,
+    membership_digest: initial.membership_digest,
+    commit_phase: 'committed',
+  };
+
+  fs.writeFileSync(path.join(root, 'src', 'beta.ts'), 'export const beta = 3;\n');
+  git(['add', 'src/beta.ts']);
+  git(['commit', '-m', 'change beta']);
+  const changedFreshness = observationFreshnessContext(root);
+  const changed = planObservationSync({
+    repositoryRoot: root,
+    generation: 'generation-a',
+    snapshot: { ...snapshot, source_revision: changedFreshness.source_revision },
+    freshness: changedFreshness,
+    previous: previousCommitted,
+    extractSignals: brownfieldSignals,
+  });
+  assert.equal(changed.envelopes.length, 2);
+  assert.equal(changed.deletes.length, 0);
+  assert.notEqual(changed.membership_digest, initial.membership_digest);
+
+  const unchanged = planObservationSync({
+    repositoryRoot: root,
+    generation: 'generation-a',
+    snapshot: { ...snapshot, source_revision: changedFreshness.source_revision },
+    freshness: changedFreshness,
+    previous: {
+      ...previousCommitted,
+      records: changed.records,
+      membership_digest: changed.membership_digest,
+      source_revision: changedFreshness.source_revision,
+      repository_revision: changedFreshness.repository_revision,
+    },
+    extractSignals: brownfieldSignals,
+  });
+  assert.equal(unchanged.envelopes.length, 0);
+  assert.equal(unchanged.deletes.length, 0);
+
+  git(['mv', 'src/alpha.ts', 'src/gamma.ts']);
+  git(['commit', '-m', 'rename alpha']);
+  const renamed = planObservationSync({
+    repositoryRoot: root,
+    generation: 'generation-a',
+    snapshot,
+    freshness: observationFreshnessContext(root),
+    previous: {
+      ...previousCommitted,
+      records: changed.records,
+      membership_digest: changed.membership_digest,
+      source_revision: changedFreshness.source_revision,
+      repository_revision: changedFreshness.repository_revision,
+    },
+    extractSignals: brownfieldSignals,
+  });
+  assert.equal(renamed.deletes.length, 1);
+  assert.ok(renamed.tombstones['src/alpha.ts']);
+  assert.ok(renamed.records['src/gamma.ts']);
+
+  git(['rm', 'src/beta.ts']);
+  git(['commit', '-m', 'delete beta']);
+  const deleted = planObservationSync({
+    repositoryRoot: root,
+    generation: 'generation-a',
+    snapshot,
+    freshness: observationFreshnessContext(root),
+    previous: {
+      ...previousCommitted,
+      generation: 'generation-a',
+      records: renamed.records,
+      tombstones: renamed.tombstones,
+      source_revision: observationFreshnessContext(root).source_revision,
+      repository_revision: observationFreshnessContext(root).repository_revision,
+    },
+    extractSignals: brownfieldSignals,
+  });
+  assert.equal(deleted.deletes.length, 1);
+  assert.ok(deleted.tombstones['src/beta.ts']);
+
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  commitGenerationState(statePath, deleted, { phase: 'pending' });
+  const pending = readGenerationState(statePath);
+  assert.equal(pending.commit_phase, 'pending');
+  assert.equal(interruptedRecoveryNeeded(pending, { generation: 'generation-a', freshness: observationFreshnessContext(root) }), true);
+
+  const recovered = planObservationSync({
+    repositoryRoot: root,
+    generation: 'generation-a',
+    snapshot,
+    freshness: observationFreshnessContext(root),
+    previous: pending,
+    extractSignals: brownfieldSignals,
+  });
+  assert.equal(recovered.interrupted_recovery, true);
+  assert.ok(recovered.envelopes.length >= 1);
+  commitGenerationState(statePath, recovered, { phase: 'committed' });
+  assert.equal(readGenerationState(statePath).commit_phase, 'committed');
+} finally {
+  removeTemporaryTree(root);
+}
+
+console.log('observation_generation_test: ok');

--- a/tests/observation_reconciliation_test.mjs
+++ b/tests/observation_reconciliation_test.mjs
@@ -56,7 +56,9 @@ try {
   assert.equal(rebuilt.observed.source_key_count, 185);
   assert.deepEqual(rebuilt.observed.source_revisions, [runtimePaths(root).source_revision]);
 
-  daemonPid = parseDaemonLock(fs.readFileSync(runtimePaths(root).lock, 'utf8'))?.pid;
+  try {
+    daemonPid = parseDaemonLock(fs.readFileSync(runtimePaths(root).lock, 'utf8'))?.pid;
+  } catch {}
 } finally {
   if (daemonPid) {
     try { await stopIncompatibleServer(runtimePaths(root), daemonPid); } catch {}

--- a/tests/retrieval_generation_test.mjs
+++ b/tests/retrieval_generation_test.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { loadManifest } from '../benchmarks/runtime-baseline-v1/contract.mjs';
+import { RETRIEVAL_SCHEMA_VERSION } from '../packages/cli/lib/retrieval-runtime/constants.mjs';
+import {
+  activateGenerationPlan,
+  commitGenerationState,
+  emptyGenerationState,
+  freshnessChanged,
+  generationStatePath,
+  interruptedRecoveryNeeded,
+  planRetrievalSync,
+  readGenerationState,
+  retrievalFreshnessContext,
+  retrievalGenerationId,
+  retrievalMembershipDigest,
+} from '../packages/cli/lib/retrieval-generation.mjs';
+import {
+  enumerateRetrievalCandidatePaths,
+  inventoryPathsDigest,
+} from '../packages/cli/lib/source-inventory.mjs';
+import { removeTemporaryTree } from './test-util.mjs';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lamina-retrieval-generation-'));
+const git = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+const statePath = generationStatePath(path.join(root, '.git', 'lamina', 'context'));
+
+try {
+  git(['init', '-b', 'main']);
+  git(['config', 'user.email', 'test@lamina.invalid']);
+  git(['config', 'user.name', 'Lamina Test']);
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'alpha.ts'), 'export const alpha = 1;\n');
+  fs.writeFileSync(path.join(root, 'src', 'beta.ts'), 'export const beta = 2;\n');
+  fs.writeFileSync(path.join(root, 'README.md'), '# docs\n');
+  fs.mkdirSync(path.join(root, 'node_modules', 'dep'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'node_modules', 'dep', 'index.js'), 'module.exports = {};\n');
+  git(['add', 'src', 'README.md']);
+  git(['commit', '-m', 'fixture']);
+
+  const freshness = retrievalFreshnessContext(root, {
+    graph_version: 'graph-v1',
+    model_digest: 'model-v1',
+    schema_version: RETRIEVAL_SCHEMA_VERSION,
+    observation_generation: 'observation-gen-a',
+    observation_membership_digest: 'a'.repeat(64),
+  });
+  assert.equal(freshness.non_canonical, true);
+  assert.equal(freshness.writes_product_truth, false);
+  assert.equal(freshness.schema_version, RETRIEVAL_SCHEMA_VERSION);
+
+  const identity = 'retrieval_test_identity';
+  const generationA = retrievalGenerationId({ identity, ...freshness });
+  const candidates = enumerateRetrievalCandidatePaths(root);
+  assert.deepEqual(candidates, ['README.md', 'src/alpha.ts', 'src/beta.ts']);
+  assert.equal(
+    inventoryPathsDigest(candidates),
+    inventoryPathsDigest(enumerateRetrievalCandidatePaths(root)),
+  );
+
+  const initial = planRetrievalSync({
+    repositoryRoot: root,
+    identity,
+    freshness,
+    previous: emptyGenerationState(),
+  });
+  assert.equal(initial.generation, generationA);
+  assert.equal(initial.source_paths.length, 3);
+  assert.equal(initial.full_reconcile, true);
+  assert.equal(initial.interrupted_recovery, false);
+
+  const committed = commitGenerationState(statePath, initial, {
+    index_digest: 'b'.repeat(64),
+    expected_count: 4,
+    committed_count: 4,
+  });
+  assert.equal(committed.commit_phase, 'committed');
+  assert.equal(readGenerationState(statePath).generation, generationA);
+
+  const pendingFreshness = retrievalFreshnessContext(root, {
+    ...freshness,
+    observation_membership_digest: 'c'.repeat(64),
+  });
+  const pending = {
+    ...initial,
+    freshness: pendingFreshness,
+    generation: retrievalGenerationId({ identity, ...pendingFreshness }),
+  };
+  commitGenerationState(statePath, pending, null, { phase: 'pending' });
+  const storedPending = readGenerationState(statePath);
+  assert.equal(
+    interruptedRecoveryNeeded(storedPending, {
+      generation: storedPending.generation,
+      freshness: pendingFreshness,
+    }),
+    true,
+  );
+  assert.equal(freshnessChanged(storedPending, freshness), true);
+
+  activateGenerationPlan(initial, {
+    index_digest: 'b'.repeat(64),
+    expected_count: 4,
+    committed_count: 4,
+  });
+  assert.throws(
+    () => activateGenerationPlan({ ...initial, index_digest: 'b'.repeat(64) }, {
+      index_digest: 'd'.repeat(64),
+      expected_count: 4,
+      committed_count: 4,
+    }),
+    /index digest is invalid/,
+  );
+
+  const { manifest } = loadManifest();
+  assert.ok(manifest.retrieval_extensions.includes('.ts'));
+} finally {
+  removeTemporaryTree(root);
+}
+
+console.log('retrieval_generation_test: ok');

--- a/tests/retrieval_native_index_test.mjs
+++ b/tests/retrieval_native_index_test.mjs
@@ -62,8 +62,10 @@ const manifest = {
   branch: 'main',
   worktree: '/native',
   model_digest: 'native-model',
+  observation_generation: '',
+  observation_membership_digest: '',
   index_digest: indexDigest,
-  schema_version: 1,
+  schema_version: 2,
   expected_count: documents.length,
 };
 

--- a/tests/retrieval_runtime_test.mjs
+++ b/tests/retrieval_runtime_test.mjs
@@ -102,8 +102,10 @@ try {
     branch: 'main',
     worktree: '/fixture',
     model_digest: 'model-one',
+    observation_generation: '',
+    observation_membership_digest: '',
     index_digest: digest(documents),
-    schema_version: 1,
+    schema_version: 2,
     expected_count: documents.length,
   };
   store.apply({

--- a/tests/retrieval_sync_test.mjs
+++ b/tests/retrieval_sync_test.mjs
@@ -65,6 +65,8 @@ try {
     path.join(root, 'src', 'planner.ts'),
   );
   fs.writeFileSync(path.join(root, 'src', 'planner.ts'), oversized);
+  execFileSync('git', ['add', '-A'], { cwd: root });
+  execFileSync('git', ['commit', '-m', 'rename and grow planner'], { cwd: root });
   const second = await ensureRetrieval(root);
   assert.notEqual(second.status.generation, firstGeneration);
   assert.equal(second.status.counts.source_chunks, 3,
@@ -79,6 +81,8 @@ try {
     'renamed source paths must not survive in the active generation');
 
   fs.rmSync(path.join(root, 'src', 'planner.ts'));
+  execFileSync('git', ['add', '-A'], { cwd: root });
+  execFileSync('git', ['commit', '-m', 'remove planner'], { cwd: root });
   const third = await ensureRetrieval(root);
   assert.equal(third.status.counts.source_chunks, 1);
   const thirdQuery = await queryRetrieval('rebuild schedule value299', third, root);

--- a/tests/runtime_budget_test.mjs
+++ b/tests/runtime_budget_test.mjs
@@ -6,6 +6,7 @@ import {
   graphdThreadEnvironment,
   maxObservationAttempts,
   observationWorkerThreadEnvironment,
+  retrievalBatchEnvironment,
   runtimeBudgetFromEnvironment,
   threadLimitEnvironment,
   workerThreadEnvironment,
@@ -21,6 +22,7 @@ assert.equal(defaultBudget.graphd_threads, 1);
 assert.equal(defaultBudget.worker_threads, 1);
 assert.equal(defaultBudget.observation_workers_max, 1);
 assert.equal(defaultBudget.observation_retries_max, 0);
+assert.equal(defaultBudget.retrieval_batch_size, 16);
 assert.equal(defaultBudget.defer_graphd_compat_recovery, true);
 assert.equal(defaultBudget.idle_graphd_shutdown_ms, 0);
 
@@ -72,8 +74,9 @@ assert.deepEqual(observationWorkerThreadEnvironment(defaultBudget), {
   LAMINA_RUNTIME_WORKER_THREADS: '1',
 });
 assert.equal(maxObservationAttempts(null), 2);
-assert.equal(maxObservationAttempts(defaultBudget), 1);
+assert.equal(maxObservationAttempts(defaultBudget), 2);
 assert.equal(maxObservationAttempts(tuned), 2);
+assert.deepEqual(retrievalBatchEnvironment(defaultBudget), { LAMINA_RUNTIME_RETRIEVAL_BATCH: '16' });
 
 const applied = applyRuntimeBudgetToEnvironment({ HOME: '/tmp' }, defaultBudget);
 assert.equal(applied.HOME, '/tmp');

--- a/tests/source_inventory_test.mjs
+++ b/tests/source_inventory_test.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { REVIEWED_INVENTORIES } from '../benchmarks/real-repository-oracle-v1/collection-authority.mjs';
+import { loadManifest } from '../benchmarks/runtime-baseline-v1/contract.mjs';
+import { brownfieldSignals } from '../packages/cli/lib/observation-runtime/node.mjs';
+import {
+  BASELINE_EXCLUSION_RULES,
+  OBSERVATION_COVERAGE_CATEGORIES,
+  OBSERVATION_IGNORE_PATTERNS,
+  buildCoverageFoundation,
+  classifyExclusion,
+  enumerateGitInventoryPaths,
+  enumerateObservationPaths,
+  inventoryPathsDigest,
+  observationInventorySnapshot,
+  sourcePathIdentity,
+  summarizePathInventory,
+} from '../packages/cli/lib/source-inventory.mjs';
+import { removeTemporaryTree } from './test-util.mjs';
+
+const { manifest } = loadManifest();
+assert.deepEqual(BASELINE_EXCLUSION_RULES, manifest.exclusions);
+assert.equal(OBSERVATION_IGNORE_PATTERNS.length, 17);
+assert.equal(OBSERVATION_COVERAGE_CATEGORIES.length, 14);
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lamina-source-inventory-'));
+const git = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+try {
+  git(['init', '-b', 'main']);
+  git(['config', 'user.email', 'test@lamina.invalid']);
+  git(['config', 'user.name', 'Lamina Test']);
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'src', 'index.ts'), 'export const FEATURE_FLAG = true;\n');
+  fs.writeFileSync(path.join(root, 'src', 'routes.ts'), "app.get('/health', handler);\n");
+  fs.writeFileSync(path.join(root, 'README.md'), '# docs\n');
+  fs.mkdirSync(path.join(root, 'node_modules', 'dep'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'node_modules', 'dep', 'index.js'), 'module.exports = {};\n');
+  fs.mkdirSync(path.join(root, '.lamina', 'runs', 'legacy'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.lamina', 'business-context.md'), '# ctx\n');
+  fs.writeFileSync(path.join(root, '.lamina', 'runs', 'legacy', 'run.json'), '{"legacy":true}\n');
+  fs.writeFileSync(path.join(root, 'scratch.ts'), 'export const scratch = 1;\n');
+  git(['add', 'src', 'README.md', '.lamina/business-context.md']);
+  git(['commit', '-m', 'fixture']);
+
+  const trackedOnly = enumerateGitInventoryPaths(root, { includeUntracked: false });
+  assert.deepEqual(trackedOnly, ['.lamina/business-context.md', 'README.md', 'src/index.ts', 'src/routes.ts']);
+
+  const withUntracked = enumerateGitInventoryPaths(root);
+  assert.ok(withUntracked.includes('scratch.ts'));
+  assert.ok(!enumerateObservationPaths(root).some((item) => item.path.startsWith('node_modules/')));
+
+  assert.equal(classifyExclusion('node_modules/dep/index.js', manifest.exclusions), 'dependency_root');
+  assert.equal(classifyExclusion('.lamina/runs/legacy/run.json', manifest.exclusions), 'lamina_run_artifacts');
+  assert.equal(classifyExclusion('src/index.ts', manifest.exclusions), null);
+
+  const observed = enumerateObservationPaths(root);
+  assert.deepEqual(observed.map((item) => item.path), ['.lamina/business-context.md', 'README.md', 'scratch.ts', 'src/index.ts', 'src/routes.ts']);
+
+  const identity = sourcePathIdentity('src/index.ts', Buffer.from('export const FEATURE_FLAG = true;\n'));
+  assert.equal(identity.source_key, 'src/index.ts');
+  assert.equal(identity.content_sha256, crypto.createHash('sha256').update('export const FEATURE_FLAG = true;\n').digest('hex'));
+  assert.equal(identity.identity_digest.length, 64);
+
+  const summary = summarizePathInventory(withUntracked, root, manifest, null);
+  assert.equal(summary.inventory.tracked_files, withUntracked.length);
+  assert.equal(summary.inventory.observation_indexed_files, observed.length);
+  assert.equal(summary.inventory.observation_paths_digest, inventoryPathsDigest(observed.map((item) => item.path)));
+  assert.equal(summary.non_canonical, true);
+  assert.equal(summary.writes_product_truth, false);
+
+  const coverage = buildCoverageFoundation(summary.entries, {
+    repository: root,
+    extractSignals: brownfieldSignals,
+  });
+  assert.ok(coverage.categories.routes.length >= 1);
+  assert.ok(coverage.categories.documentation.length >= 1);
+  assert.equal(coverage.non_canonical, true);
+  assert.equal(coverage.writes_product_truth, false);
+
+  const snapshot = observationInventorySnapshot(root, { extractSignals: brownfieldSignals });
+  assert.equal(snapshot.schema, 'lamina.source-inventory/v1');
+  assert.equal(snapshot.non_canonical, true);
+  assert.equal(snapshot.writes_product_truth, false);
+  assert.deepEqual(snapshot.exclusion_rules, manifest.exclusions);
+  assert.equal(snapshot.inventory.observation_indexed_files, observed.length);
+} finally {
+  removeTemporaryTree(root);
+}
+
+assert.equal(
+  REVIEWED_INVENTORIES.small.observation_paths_digest,
+  'a751c5ae498aad42ec231daf714f8bede3e76f1d6f083ccbe3b6097f666b07cc',
+  'reviewed small fixture observation digest remains frozen',
+);
+
+console.log('source_inventory_test: ok');


### PR DESCRIPTION
## Summary

- Cherry-picks the minimal CLI/product surface from #71–#73: source inventory, observation generation invalidation, and retrieval index construction/sync aligned with observation membership.
- Bumps retrieval schema to v2 (`observation_generation`, `observation_membership_digest`) and migrates PR1 retrieval databases that lack those columns.
- Stacks on #89 (`release/minimal-bounded-runtime`) so bounded observation + lifecycle remain the base.

## Test plan

- [x] `node tests/source_inventory_test.mjs`
- [x] `node tests/observation_generation_test.mjs`
- [x] `node tests/retrieval_generation_test.mjs`
- [x] `node tests/retrieval_runtime_test.mjs`
- [x] `node tests/retrieval_sync_test.mjs`
- [x] `node tests/runtime_budget_test.mjs`
- [x] `node tests/runtime_lifecycle_test.mjs`
- [x] Smoke: `graph observe` → `context rebuild` on fresh temp repo (deterministic embedder)
- [ ] Merge #89 first, then this PR, then tag `cli-v0.3.6`


Made with [Cursor](https://cursor.com)